### PR TITLE
Add a message on memory limit when running remote build

### DIFF
--- a/Kudu.Core/Helpers/LinuxConsumptionDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/LinuxConsumptionDeploymentHelper.cs
@@ -33,6 +33,10 @@ namespace Kudu.Core.Helpers
             string packageFolder = env.ArtifactsPath;
             string packageFileName = OryxBuildConstants.FunctionAppBuildSettings.LinuxConsumptionArtifactName;
 
+            // Indicate the memory limitation on Linux Consumption
+            context.Logger.Log($"Linux Consumption plan has a 1.5 GB memory limit on a remote build container.");
+            context.Logger.Log($"To check our service limit, please visit https://docs.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits");
+
             // Try create a placeholder blob in AzureWebJobsStorage
             CloudBlockBlob blob = await GetPlaceholderBlob(context, settings, shouldUpdateWebsiteRunFromPackage);
 


### PR DESCRIPTION
Some customers are using KuduLite to run remote build on large third-party packages, and run into OutOfMemory error.
https://github.com/Azure/azure-functions-python-worker/issues/686

We want to notify customer that our build container only has 1.5 GB memory in it.