### PR TITLE
Minor fixes to Linux Consumption

### DIFF
--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -503,7 +503,7 @@ namespace Kudu.Services.Web
                     new {controller = "LinuxConsumptionInstanceAdmin", action = "Info"},
                     new {verb = new HttpMethodRouteConstraint("GET")});
                 routes.MapRoute("admin-instance-assign", "admin/instance/assign",
-                    new {controller = "LinuxConsumptionInstanceAdmin", action = "AssignAsync" },
+                    new {controller = "LinuxConsumptionInstanceAdmin", action = "Assign" },
                     new {verb = new HttpMethodRouteConstraint("POST")});
 
                 // Live Command Line

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionInstanceAdminController.cs
@@ -62,7 +62,7 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
         /// <returns>Expect 202 when receives the first call, otherwise, returns 409</returns>
         [HttpPost]
         [Authorize(Policy = AuthPolicyNames.AdminAuthLevel)]
-        public async Task<IActionResult> AssignAsync([FromBody] EncryptedHostAssignmentContext encryptedAssignmentContext)
+        public IActionResult Assign([FromBody] EncryptedHostAssignmentContext encryptedAssignmentContext)
         {
             var containerKey = System.Environment.GetEnvironmentVariable(SettingsKeys.ContainerEncryptionKey);
             var assignmentContext = encryptedAssignmentContext.Decrypt(containerKey);

--- a/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionRouteMiddleware.cs
+++ b/Kudu.Services/LinuxConsumptionInstanceAdmin/LinuxConsumptionRouteMiddleware.cs
@@ -31,7 +31,8 @@ namespace Kudu.Services.LinuxConsumptionInstanceAdmin
             "/api/settings",
             "/admin/instance",
             "/deployments",
-            "/zipdeploy"
+            "/zipdeploy",
+            "/Error"
         };
 
         private readonly RequestDelegate _next;


### PR DESCRIPTION
The assign endpoint should be synchronous.
The /Error endpoint should also be exposed, otherwise it will swallow 500 exceptions and returns 404.