### PR TITLE
Add support for ARM requests for zip deploy with remote url

### DIFF
--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -120,7 +120,8 @@ namespace Kudu.Services.Deployment
         {
             using (_tracer.Step("ZipPushDeployViaUrl"))
             {
-                string zipUrl = GetArtifactURLFromJSON(requestJson);
+                // ARM Request payload is wrapped in properties {'properties':{'uri':''}}
+                string zipUrl = ArmUtils.IsArmRequest(Request) ? GetArticfactURLFromARMJSON(requestJson) : GetArtifactURLFromJSON(requestJson);
 
                 var deploymentInfo = new ArtifactDeploymentInfo(_environment, _traceFactory)
                 {
@@ -253,7 +254,7 @@ namespace Kudu.Services.Deployment
                             ignoreStack = requestJson.Value<bool>("ignorestack");
                         }
 
-                        remoteArtifactUrl = GetArtifactURLFromJSON(requestJson);
+                        remoteArtifactUrl = ArmUtils.IsArmRequest(Request) ? GetArticfactURLFromARMJSON(requestJson) : GetArtifactURLFromJSON(requestJson);
                     }
                 }
                 catch (Exception ex)
@@ -419,6 +420,28 @@ namespace Kudu.Services.Deployment
         private ObjectResult StatusCode400(string message)
         {
             return StatusCode(StatusCodes.Status400BadRequest, message);
+        }
+
+        private string GetArticfactURLFromARMJSON(JObject requestObject)
+        {
+            using (_tracer.Step("Reading the artifact URL from the ARM request JSON"))
+            {
+                try
+                {
+                    // ARM template should have properties field and a packageUri field inside the properties field.
+                    string packageUri = requestObject.Value<JObject>("properties").Value<string>("packageUri");
+                    if (string.IsNullOrEmpty(packageUri))
+                    {
+                        throw new ArgumentException("Invalid Url in the JSON request");
+                    }
+                    return packageUri;
+                }
+                catch (Exception ex)
+                {
+                    _tracer.TraceError(ex, "Error reading the URL from the JSON {0}", requestObject.ToString());
+                    throw;
+                }
+            }
         }
 
         private string GetArtifactURLFromJSON(JObject requestObject)


### PR DESCRIPTION
The ARM Request Payload is wrapped in a key `properties`. This PR adds support to parse the arm requests correctly.