### PR TITLE
Kudu + KEDA publishing for Durable Functions on SQL

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -141,6 +141,9 @@ namespace Kudu
         public const string HubName = "HubName";
         public const string DurableTaskStorageConnection = "connection";
         public const string DurableTaskStorageConnectionName = "azureStorageConnectionStringName";
+        public const string DurableTaskSqlConnectionName = "connectionStringName";
+        public const string DurableTaskStorageProvider = "storageProvider";
+        public const string DurableTaskMicrosoftSqlProviderType = "MicrosoftSQL";
         public const string DurableTask = "durableTask";
         public const string Extensions = "extensions";
         public const string SitePackages = "SitePackages";

--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -144,6 +144,7 @@ namespace Kudu
         public const string DurableTaskSqlConnectionName = "connectionStringName";
         public const string DurableTaskStorageProvider = "storageProvider";
         public const string DurableTaskMicrosoftSqlProviderType = "MicrosoftSQL";
+        public const string MicrosoftSqlScaler = "mssql";
         public const string DurableTask = "durableTask";
         public const string Extensions = "extensions";
         public const string SitePackages = "SitePackages";

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -207,6 +207,8 @@ namespace Kudu.Core.Functions
                     Type = "mssql",
                     Metadata = new Dictionary<string, string>
                     {
+                        ["query"] = "SELECT dt.GetScaleMetric()",
+                        ["targetValue"] = "1", // super-conservative default
                         ["connectionStringFromEnv"] = storageProviderConfig?["connectionStringName"]?.ToString(),
                     }
                 };

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -205,7 +205,7 @@ namespace Kudu.Core.Functions
                 scaleTrigger = new ScaleTrigger
                 {
                     // MSSQL scaler reference: https://keda.sh/docs/2.2/scalers/mssql/
-                    Type = "mssql",
+                    Type = Constants.MicrosoftSqlScaler,
                     Metadata = new Dictionary<string, string>
                     {
                         ["query"] = "SELECT dt.GetScaleMetric()",

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -21,9 +21,19 @@ namespace Kudu.Core.Functions
                 return null;
             }
 
-            List<ScaleTrigger> kedaScaleTriggers = new List<ScaleTrigger>();
+            string hostJsonText = null;
+            var triggerBindings = new List<FunctionTrigger>();
             using (var zip = ZipFile.OpenRead(zipFilePath))
             {
+                var hostJsonEntry = zip.Entries.FirstOrDefault(e => IsHostJson(e.FullName));
+                if (hostJsonEntry != null)
+                {
+                    using (var reader = new StreamReader(hostJsonEntry.Open()))
+                    {
+                        hostJsonText = reader.ReadToEnd();
+                    }
+                }
+
                 var entries = zip.Entries
                     .Where(e => IsFunctionJson(e.FullName));
 
@@ -33,14 +43,22 @@ namespace Kudu.Core.Functions
                     {
                         using (var reader = new StreamReader(stream))
                         {
-                            var functionTriggers = ParseFunctionJson(GetFunctionName(entry), reader.ReadToEnd());
-                            if (functionTriggers?.Any() == true)
-                            {
-                                kedaScaleTriggers.AddRange(functionTriggers);
-                            }
+                            triggerBindings.AddRange(ParseFunctionJson(GetFunctionName(entry), reader.ReadToEnd()));
                         }
                     }
                 }
+            }
+
+            var durableTriggers = triggerBindings.Where(b => IsDurable(b));
+            var standardTriggers = triggerBindings.Where(b => !IsDurable(b));
+
+            var kedaScaleTriggers = new List<ScaleTrigger>();
+            kedaScaleTriggers.AddRange(GetStandardScaleTriggers(standardTriggers));
+
+            // Durable Functions triggers are treated as a group and get configuration from host.json
+            if (durableTriggers.Any() && TryGetDurableKedaTrigger(hostJsonText, out ScaleTrigger durableScaleTrigger))
+            {
+                kedaScaleTriggers.Add(durableScaleTrigger);
             }
 
             bool IsFunctionJson(string fullName)
@@ -49,10 +67,15 @@ namespace Kudu.Core.Functions
                        fullName.Count(c => c == '/' || c == '\\') == 1;
             }
 
+            bool IsHostJson(string fullName)
+            {
+                return fullName.Equals("host.json", StringComparison.OrdinalIgnoreCase);
+            }
+
             return kedaScaleTriggers;
         }
 
-        public IEnumerable<ScaleTrigger> ParseFunctionJson(string functionName, string functionJson)
+        public IEnumerable<FunctionTrigger> ParseFunctionJson(string functionName, string functionJson)
         {
             var json = JObject.Parse(functionJson);
             if (json.TryGetValue("disabled", out JToken value))
@@ -67,51 +90,56 @@ namespace Kudu.Core.Functions
 
                 if (disabled)
                 {
-                    return null;
+                    yield break;
                 }
             }
 
             var excluded = json.TryGetValue("excluded", out value) && (bool)value;
             if (excluded)
             {
-                return null;
+                yield break;
             }
 
-            var triggers = new List<ScaleTrigger>();
             foreach (JObject binding in (JArray)json["bindings"])
             {
                 var type = (string)binding["type"];
                 if (type.EndsWith("Trigger", StringComparison.OrdinalIgnoreCase))
                 {
-                    var scaleTrigger = new ScaleTrigger
-                    {
-                        Type = GetKedaTriggerType(type),
-                        Metadata = new Dictionary<string, string>()
-                    };
-                    foreach (var property in binding)
-                    {
-                        if (property.Value.Type == JTokenType.String)
-                        {
-                            scaleTrigger.Metadata.Add(property.Key, property.Value.ToString());
-                        }
-                    }
-
-                    scaleTrigger.Metadata.Add("functionName", functionName);
-                    triggers.Add(scaleTrigger);
+                    yield return new FunctionTrigger(functionName, binding, type);
                 }
             }
-
-            return triggers;
         }
 
-        private static string GetFunctionName(ZipArchiveEntry zipEnetry)
+        private static IEnumerable<ScaleTrigger> GetStandardScaleTriggers(IEnumerable<FunctionTrigger> standardTriggers)
         {
-            if (string.IsNullOrWhiteSpace(zipEnetry?.FullName))
+            foreach (FunctionTrigger function in standardTriggers)
+            {
+                var scaleTrigger = new ScaleTrigger
+                {
+                    Type = GetKedaTriggerType(function.Type),
+                    Metadata = new Dictionary<string, string>()
+                };
+                foreach (var property in function.Binding)
+                {
+                    if (property.Value.Type == JTokenType.String)
+                    {
+                        scaleTrigger.Metadata.Add(property.Key, property.Value.ToString());
+                    }
+                }
+
+                scaleTrigger.Metadata.Add("functionName", function.FunctionName);
+                yield return scaleTrigger;
+            }
+        }
+
+        private static string GetFunctionName(ZipArchiveEntry zipEntry)
+        {
+            if (string.IsNullOrWhiteSpace(zipEntry?.FullName))
             {
                 return string.Empty;
             }
 
-            return zipEnetry.FullName.Split('/').Length == 2 ? zipEnetry.FullName.Split('/')[0] : zipEnetry.FullName.Split('\\')[0];
+            return zipEntry.FullName.Split('/').Length == 2 ? zipEntry.FullName.Split('/')[0] : zipEntry.FullName.Split('\\')[0];
         }
 
         public static string GetKedaTriggerType(string triggerType)
@@ -149,6 +177,60 @@ namespace Kudu.Core.Functions
                 default:
                     return triggerType;
             }
+        }
+        
+        private static bool IsDurable(FunctionTrigger function) => 
+            function.Type.Equals("orchestrationTrigger", StringComparison.OrdinalIgnoreCase) ||
+            function.Type.Equals("activityTrigger", StringComparison.OrdinalIgnoreCase) ||
+            function.Type.Equals("entityTrigger", StringComparison.OrdinalIgnoreCase);
+
+        private static bool TryGetDurableKedaTrigger(string hostJsonText, out ScaleTrigger scaleTrigger)
+        {
+            scaleTrigger = null;
+            if (string.IsNullOrEmpty(hostJsonText))
+            {
+                return false;
+            }
+
+            JObject hostJson = JObject.Parse(hostJsonText);
+
+            // Reference: https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-bindings#durable-functions-2-0-host-json
+            JObject storageProviderConfig = hostJson.SelectToken("extensions.durableTask.storageProvider") as JObject;
+            string storageType = storageProviderConfig?["type"]?.ToString();
+
+            // Custom storage types are supported starting in Durable Functions v2.4.2
+            if (string.Equals(storageType, "MicrosoftSQL", StringComparison.OrdinalIgnoreCase))
+            {
+                scaleTrigger = new ScaleTrigger
+                {
+                    // MSSQL scaler reference: https://keda.sh/docs/2.2/scalers/mssql/
+                    Type = "mssql",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["connectionStringFromEnv"] = storageProviderConfig?["connectionStringName"]?.ToString(),
+                    }
+                };
+            }
+            else
+            {
+                // TODO: Support for the Azure Storage and Netherite backends
+            }
+
+            return scaleTrigger != null;
+        }
+
+        public class FunctionTrigger
+        {
+            public FunctionTrigger(string functionName, JObject binding, string type)
+            {
+                this.FunctionName = functionName;
+                this.Binding = binding;
+                this.Type = type;
+            }
+
+            public string FunctionName { get; }
+            public JObject Binding { get; }
+            public string Type { get; }
         }
     }
 }

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -1,0 +1,57 @@
+using Kudu.Core.Functions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Xunit;
+
+namespace Kudu.Tests.Core.Function
+{
+    public class KedaFunctionTriggersProviderTests
+    {
+        [Fact]
+        public void DurableFunctionApp()
+        {
+            // Generate a zip archive with a host.json and the contents of a Durable Function app
+            string zipFilePath = Path.GetTempFileName();
+            using (var fileStream = File.OpenWrite(zipFilePath))
+            using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                CreateJsonFileEntry(archive, "host.json", @"{""version"":""2.0"",""extensions"":{""durableTask"":{""hubName"":""DFTest"",""storageProvider"":{""type"":""MicrosoftSQL"",""connectionStringName"":""SQLDB_Connection""}}}}");
+                CreateJsonFileEntry(archive, "f1/function.json", @"{""bindings"":[{""type"":""orchestrationTrigger"",""name"":""context""}],""disabled"":false}");
+                CreateJsonFileEntry(archive, "f2/function.json", @"{""bindings"":[{""type"":""entityTrigger"",""name"":""ctx""}],""disabled"":false}");
+                CreateJsonFileEntry(archive, "f3/function.json", @"{""bindings"":[{""type"":""activityTrigger"",""name"":""input""}],""disabled"":false}");
+                CreateJsonFileEntry(archive, "f4/function.json", @"{""bindings"":[{""type"":""httpTrigger"",""methods"":[""post""],""authLevel"":""anonymous"",""name"":""req""}],""disabled"":false}");
+            }
+
+            try
+            {
+                var provider = new KedaFunctionTriggerProvider();
+                IEnumerable<ScaleTrigger> result = provider.GetFunctionTriggers(zipFilePath);
+                Assert.Equal(2, result.Count());
+
+                ScaleTrigger mssqlTrigger = Assert.Single(result, trigger => trigger.Type.Equals("mssql", StringComparison.OrdinalIgnoreCase));
+                string connectionStringName = Assert.Contains("connectionStringFromEnv", mssqlTrigger.Metadata);
+                Assert.Equal("SQLDB_Connection", connectionStringName);
+
+                ScaleTrigger httpTrigger = Assert.Single(result, trigger => trigger.Type.Equals("httpTrigger", StringComparison.OrdinalIgnoreCase));
+                string functionName = Assert.Contains("functionName", httpTrigger.Metadata);
+                Assert.Equal("f4", functionName);
+            }
+            finally
+            {
+                File.Delete(zipFilePath);
+            }
+        }
+
+        private static void CreateJsonFileEntry(ZipArchive archive, string path, string content)
+        {
+            using (Stream entryStream = archive.CreateEntry(path).Open())
+            using (var streamWriter = new StreamWriter(entryStream))
+            {
+                streamWriter.Write(content);
+            }
+        }
+    }
+}

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -32,8 +32,15 @@ namespace Kudu.Tests.Core.Function
                 Assert.Equal(2, result.Count());
 
                 ScaleTrigger mssqlTrigger = Assert.Single(result, trigger => trigger.Type.Equals("mssql", StringComparison.OrdinalIgnoreCase));
+                string query = Assert.Contains("query", mssqlTrigger.Metadata);
+                Assert.False(string.IsNullOrEmpty(query));
+
+                string targetValue = Assert.Contains("targetValue", mssqlTrigger.Metadata);
+                Assert.False(string.IsNullOrEmpty(targetValue));
+                Assert.True(double.TryParse(targetValue, out _));
+
                 string connectionStringName = Assert.Contains("connectionStringFromEnv", mssqlTrigger.Metadata);
-                Assert.Equal("SQLDB_Connection", connectionStringName);
+                Assert.Equal("SQLDB_Connection", connectionStringName);                
 
                 ScaleTrigger httpTrigger = Assert.Single(result, trigger => trigger.Type.Equals("httpTrigger", StringComparison.OrdinalIgnoreCase));
                 string functionName = Assert.Contains("functionName", httpTrigger.Metadata);


### PR DESCRIPTION
This PR adds support for publishing function apps with Durable Functions triggers that are configured with the new [SQL backend](https://microsoft.github.io/durabletask-mssql).

I had to refactor the existing code a bit since Durable scalers are not 1:1 with function triggers, like they are for all other trigger types. Rather, all durable triggers in a single function app are powered by a single scaler.

I also added a unit test to verify the behavior.