### PR TITLE
Adding api to retrieve environment variables

### DIFF
--- a/Kudu.Contracts/Diagnostics/ProcessEnvironmentInfo.cs
+++ b/Kudu.Contracts/Diagnostics/ProcessEnvironmentInfo.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Kudu.Contracts.Infrastructure;
+using Newtonsoft.Json;
+
+namespace Kudu.Contracts.Diagnostics
+{
+    public class ProcessEnvironmentInfo : Dictionary<string, string>, INamedObject
+    {
+        private readonly string _name;
+
+        public ProcessEnvironmentInfo()
+        {
+        }
+
+        public ProcessEnvironmentInfo(string name, Dictionary<string, string> values)
+            : base(values)
+        {
+            _name = name;
+        }
+
+        [JsonProperty(PropertyName = "name")]
+        string INamedObject.Name { get { return _name; } }
+    }
+}

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -678,6 +678,9 @@ namespace Kudu.Services.Web
                 routes.MapHttpProcessesRoute("one-process-module", "/{id}/modules/{baseAddress}",
                     new {controller = processControllerName, action = "GetModule"},
                     new {verb = new HttpMethodRouteConstraint("GET")});
+                routes.MapHttpProcessesRoute("all-envs", "/{id}/environments/{filter}",
+                    new { controller = processControllerName, action = "GetEnvironments" },
+                    new { verb = new HttpMethodRouteConstraint("GET") });
 
                 // Runtime
                 routes.MapHttpRouteDual("runtime", "diagnostics/runtime",

--- a/Kudu.Services/Diagnostics/LinuxProcessController.cs
+++ b/Kudu.Services/Diagnostics/LinuxProcessController.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net;
+using Kudu.Contracts.Diagnostics;
+using Kudu.Services.Arm;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Kudu.Services.Performance
@@ -90,6 +95,17 @@ namespace Kudu.Services.Performance
         {
             Response.StatusCode = (int)HttpStatusCode.BadRequest;
             return new JsonResult(ERRORMSG);
+        }
+
+        [HttpGet]
+        public IActionResult GetEnvironments(int id, string filter)
+        {
+            var envs = System.Environment.GetEnvironmentVariables()
+                .Cast<DictionaryEntry>().ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value.ToString())
+                .Where(p => string.Equals("all", filter, StringComparison.OrdinalIgnoreCase) || p.Key.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
+                .ToDictionary(p => p.Key, p => p.Value);
+
+            return Ok(ArmUtils.AddEnvelopeOnArmRequest(new ProcessEnvironmentInfo(filter, envs), Request));
         }
     }
 }


### PR DESCRIPTION
Adding an endpoint to retrieve environment variables. This is needed by the App Service platform to get information about the running app's environment (mainly Key Vault reference statuses).

Work on Kudu: https://github.com/projectkudu/kudu/commit/0728d16a0c9d6e625064f61458b68ab6d87053d3