### PR TITLE
Updates for Durable SQL v0.7.0-alpha changes

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -143,7 +143,7 @@ namespace Kudu
         public const string DurableTaskStorageConnectionName = "azureStorageConnectionStringName";
         public const string DurableTaskSqlConnectionName = "connectionStringName";
         public const string DurableTaskStorageProvider = "storageProvider";
-        public const string DurableTaskMicrosoftSqlProviderType = "MicrosoftSQL";
+        public const string DurableTaskMicrosoftSqlProviderType = "mssql";
         public const string MicrosoftSqlScaler = "mssql";
         public const string DurableTask = "durableTask";
         public const string Extensions = "extensions";

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -200,6 +200,7 @@ namespace Kudu.Core.Functions
             string storageType = storageProviderConfig?["type"]?.ToString();
 
             // Custom storage types are supported starting in Durable Functions v2.4.2
+            // Minimum required version of Microsoft.DurableTask.SqlServer.AzureFunctions is v0.7.0-alpha
             if (string.Equals(storageType, Constants.DurableTaskMicrosoftSqlProviderType, StringComparison.OrdinalIgnoreCase))
             {
                 scaleTrigger = new ScaleTrigger
@@ -208,8 +209,9 @@ namespace Kudu.Core.Functions
                     Type = Constants.MicrosoftSqlScaler,
                     Metadata = new Dictionary<string, string>
                     {
-                        ["query"] = "SELECT dt.GetScaleMetric()",
-                        ["targetValue"] = "1", // super-conservative default
+                        // Durable SQL scaling: https://microsoft.github.io/durabletask-mssql/#/scaling?id=worker-auto-scale
+                        ["query"] = "SELECT dt.GetScaleRecommendation(10, 1)", // max 10 orchestrations and 1 activity per replica
+                        ["targetValue"] = "1",
                         ["connectionStringFromEnv"] = storageProviderConfig?[Constants.DurableTaskSqlConnectionName]?.ToString(),
                     }
                 };

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -19,7 +19,7 @@ namespace Kudu.Tests.Core.Function
             using (var fileStream = File.OpenWrite(zipFilePath))
             using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create, leaveOpen: true))
             {
-                CreateJsonFileEntry(archive, "host.json", @"{""version"":""2.0"",""extensions"":{""durableTask"":{""hubName"":""DFTest"",""storageProvider"":{""type"":""MicrosoftSQL"",""connectionStringName"":""SQLDB_Connection""}}}}");
+                CreateJsonFileEntry(archive, "host.json", @"{""version"":""2.0"",""extensions"":{""durableTask"":{""hubName"":""DFTest"",""storageProvider"":{""type"":""mssql"",""connectionStringName"":""SQLDB_Connection""}}}}");
                 CreateJsonFileEntry(archive, "f1/function.json", @"{""bindings"":[{""type"":""orchestrationTrigger"",""name"":""context""}],""disabled"":false}");
                 CreateJsonFileEntry(archive, "f2/function.json", @"{""bindings"":[{""type"":""entityTrigger"",""name"":""ctx""}],""disabled"":false}");
                 CreateJsonFileEntry(archive, "f3/function.json", @"{""bindings"":[{""type"":""activityTrigger"",""name"":""input""}],""disabled"":false}");


### PR DESCRIPTION
We made some changes in the v0.7.0-alpha release that require updates to KuduLite. Specifically:

* The type name of the SQL backend was changed from "MicrosoftSQL" to "mssql"
* The default mssql scaler trigger query has been changed to `SELECT dt.GetScaleRecommendation(10, 1)`

Similar changes have already been merged for the Azure Functions Core Tools.

@sanchitmehta would it be possible for us to take these changes for the upcoming 4/19 KuduLite release?

Tagging @pragnagopa and @JennyLawrance for visibility.