### PR TITLE
Fix null reference exception while deployment in Linux app

### DIFF
--- a/Kudu.Contracts/Infrastructure/LockExtensions.cs
+++ b/Kudu.Contracts/Infrastructure/LockExtensions.cs
@@ -47,8 +47,7 @@ namespace Kudu.Contracts.Infrastructure
 
             if (!success)
             {
-                var lockInfo = lockObj.LockInfo;
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
+                ThrowLockOperationException(lockObj, operationName);
             }
         }
 
@@ -60,8 +59,7 @@ namespace Kudu.Contracts.Infrastructure
 
             if (!success)
             {
-                var lockInfo = lockObj.LockInfo;
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, operationName,""));
+                ThrowLockOperationException(lockObj, operationName);
             }
 
             return result;
@@ -72,8 +70,7 @@ namespace Kudu.Contracts.Infrastructure
             bool isLocked = await WaitToLockAsync(lockObj, operationName, timeout);
             if (!isLocked)
             {
-                var lockInfo = lockObj.LockInfo;
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
+                ThrowLockOperationException(lockObj, operationName);
             }
 
             try
@@ -91,8 +88,7 @@ namespace Kudu.Contracts.Infrastructure
             bool isLocked = await WaitToLockAsync(lockObj, operationName, timeout);
             if (!isLocked)
             {
-                var lockInfo = lockObj.LockInfo;
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
+                ThrowLockOperationException(lockObj, operationName);
             }
 
             try
@@ -121,6 +117,16 @@ namespace Kudu.Contracts.Infrastructure
             }
 
             return true;
+        }
+
+        private static void ThrowLockOperationException(IOperationLock lockObj, string operationName)
+        {
+            var lockInfo = lockObj.LockInfo;
+
+            string lockedOperationName = lockInfo?.OperationName ?? "unknown";
+            string lockAcquiredDateTime = lockInfo?.AcquiredDateTime ?? "unknown";
+
+            throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockedOperationName, lockAcquiredDateTime));
         }
     }
 }

--- a/Kudu.Core/AllSafeLinuxLock.cs
+++ b/Kudu.Core/AllSafeLinuxLock.cs
@@ -21,7 +21,8 @@ namespace Kudu.Core
         private static readonly string locksPath = "/home/site/locks";
 	    private const int defaultLockTimeout = 1500; //in seconds
         private string defaultMsg = Resources.DeploymentLockOccMsg;
-        private static string LockExpiry = null;
+        private static object LockExpiryLock = new object();
+        private static DateTime LockExpiry = DateTime.MinValue;
         private string Msg;
         public AllSafeLinuxLock(string path, ITraceFactory traceFactory)
         {
@@ -78,9 +79,9 @@ namespace Kudu.Core
             // At this point we have already checked for the folder presence
             // hence to avoid the I/O, don't serialize the lock info until
             // folder is cleaned up
-            if(!string.IsNullOrEmpty(LockExpiry))
+            lock (LockExpiryLock)
             {
-                if(Convert.ToDateTime(LockExpiry) > DateTime.Now)
+                if (LockExpiry > DateTime.UtcNow)
                 {
                     return true;
                 }
@@ -99,7 +100,10 @@ namespace Kudu.Core
             }
             
             var exp = Convert.ToDateTime(expStr);
-            LockExpiry = expStr;
+            lock (LockExpiryLock)
+            {
+                LockExpiry = exp;
+            }
             if (exp > DateTime.UtcNow)
             {
                 return true;
@@ -122,7 +126,42 @@ namespace Kudu.Core
             FileSystemHelpers.WriteAllText(locksPath+"/deployment/info.lock",json);
         }
         
-        public OperationLockInfo LockInfo { get; }
+        public OperationLockInfo LockInfo
+        {
+            get
+            {
+                if (!FileSystemHelpers.FileExists(locksPath + "/deployment/info.lock"))
+                {
+                    return null;
+                }
+
+                try
+                {
+                    var lockInfo = JObject.Parse(File.ReadAllText(locksPath + "/deployment/info.lock"));
+                    var expStr = lockInfo["lockExpiry"].ToString();
+
+                    //Should never have null expiry
+                    if (string.IsNullOrEmpty(expStr) || !DateTime.TryParse(expStr, out DateTime exp))
+                    {
+                        Console.WriteLine($"LockInfo: Invalid lockExpiry found: {expStr}");
+                        return null;
+                    }
+
+                    var opLockInfo = new OperationLockInfo();
+
+                    opLockInfo.AcquiredDateTime = exp.AddSeconds(-defaultLockTimeout).ToString("o");
+                    opLockInfo.OperationName = lockInfo["heldByOp"].ToString();
+                    opLockInfo.InstanceId = lockInfo["heldByWorker"].ToString();
+
+                    return opLockInfo;
+                }
+                catch(Exception ex)
+                {
+                    _traceFactory.GetTracer().TraceError(ex);
+                    return null;
+                }
+            }
+        }
         
         public bool Lock(string operationName)
         {
@@ -157,7 +196,10 @@ namespace Kudu.Core
 
         public void Release()
         {
-            LockExpiry = null;
+            lock (LockExpiryLock)
+            {
+                LockExpiry = DateTime.MinValue;
+            }
             if (FileSystemHelpers.DirectoryExists(locksPath+"/deployment"))
             {
                 //Console.WriteLine("Releasing Lock - RemovingDir");

--- a/Kudu.Core/AllSafeLinuxLock.cs
+++ b/Kudu.Core/AllSafeLinuxLock.cs
@@ -58,11 +58,9 @@ namespace Kudu.Core
                     finally
                     {
                         // There is some problem with reading the lock info file
-                        // Avoid deadlock by releasing this lock/removing the dir
                         if (exception!=null)
                         {
-                            _traceFactory.GetTracer().Trace("IsHeld - there were exceptions twice -releasing the lock - ie deleting the lock directory");
-                            FileSystemHelpers.DeleteDirectorySafe(locksPath+"/deployment");
+                            _traceFactory.GetTracer().Trace("IsHeld - there were exceptions twice. Something was wrong.");
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes null reference exception which occurred during a deployment operation on Linux apps.

Exception signature:
Error occurred type= error text= Object reference not set to an instance of an object. stackTrace=
  at Kudu.Contracts.Infrastructure.LockExtensions.LockOperation(IOperationLock lockObj, Action operation, String operationName, TimeSpan timeout) in /tmp/KuduLite/Kudu.Contracts/Infrastructure/LockExtensions.cs:line 51
  at Kudu.Core.Deployment.FetchDeploymentManager.<>c__DisplayClass13_0.b__1() in /tmp/KuduLite/Kudu.Core/Deployment/FetchDeploymentManager.cs:line 435