### PR TITLE
Logic app scaler bugfix and zipdeploy k8se deploy try add instead of add

### DIFF
--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -316,7 +316,7 @@ namespace Kudu.Core.Functions
                     // NOTE(haassyad): We only have one queue partition in single tenant.
                     ["queueName"] = StringHelper.GetWorkflowQueueNameInternal(queuePrefix, 1),
                     ["queueLength"] = queueLength,
-                    ["connectionStringFromEnv"] = "AzureWebJobsStorage",
+                    ["connectionFromEnv"] = "AzureWebJobsStorage",
                 }
             };
 

--- a/Kudu.Core/K8SE/K8SEDeploymentHelper.cs
+++ b/Kudu.Core/K8SE/K8SEDeploymentHelper.cs
@@ -171,7 +171,7 @@ namespace Kudu.Core.K8SE
                 var key = setting.Key.Substring(appSettingsPrefix.Length);
                 appSettings[key] = setting.Value;
             }
-            context.Items.Add("appSettings", appSettings);
+            context.Items.TryAdd("appSettings", appSettings);
         }
 
         private static string GetFunctionAppPatchJson(IEnumerable<ScaleTrigger> functionTriggers, BuildMetadata buildMetadata)

--- a/Kudu.Services.Web/KubeMiddleware.cs
+++ b/Kudu.Services.Web/KubeMiddleware.cs
@@ -64,10 +64,10 @@ namespace Kudu.Services.Web
             }
 
             // Cache the App Environment for this request
-            context.Items.Add("environment", GetEnvironment(homeDir, appName, null, null, appNamenamespace, appType));
+            context.Items.TryAdd("environment", GetEnvironment(homeDir, appName, null, null, appNamenamespace, appType));
 
             // Cache the appName for this request
-            context.Items.Add("appName", appName);
+            context.Items.TryAdd("appName", appName);
 
             // Add All AppSettings to the context.
             K8SEDeploymentHelper.UpdateContextWithAppSettings(context);
@@ -75,7 +75,7 @@ namespace Kudu.Services.Web
             // Cache the appNamenamespace for this request if it's not empty or null
             if (!string.IsNullOrEmpty(appNamenamespace))
             {
-                context.Items.Add("appNamespace", appNamenamespace);
+                context.Items.TryAdd("appNamespace", appNamenamespace);
             }
 
             string[] pathParts = context.Request.Path.ToString().Split("/");

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -82,7 +82,7 @@ namespace Kudu.Tests.Core.Function
                 var actualQueueLength = Assert.Contains("queueLength", queueTrigger.Metadata);
                 Assert.Equal(actualQueueLength, expectedQueueLength);
 
-                string connectionStringFromEnv = Assert.Contains("connectionStringFromEnv", queueTrigger.Metadata);
+                string connectionStringFromEnv = Assert.Contains("connectionFromEnv", queueTrigger.Metadata);
                 Assert.Equal("AzureWebJobsStorage", connectionStringFromEnv);
             }
             finally


### PR DESCRIPTION
Had a bug when creating the scale trigger for logic app, as well as seeing 500 errors when doing api/zipdeploy. Turns out some properties key are already set on the context and we where doing an Add()