### PR TITLE
Fix: [Functions][Kubernetes]SyncTrigger issue

### DIFF
--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -112,6 +112,12 @@ namespace Kudu.Core.Functions
             return CreateScaleTriggers(triggerBindings, hostJsonText, appSettings);
         }
 
+        public static IEnumerable<ScaleTrigger> GetFunctionTriggersFromSyncTriggerPayload(string synctriggerPayload,
+            string hostJsonText, IDictionary<string, string> appSettings)
+        {
+            return CreateScaleTriggers(ParseSyncTriggerPayload(synctriggerPayload), hostJsonText, appSettings);
+        }
+
         internal static IEnumerable<ScaleTrigger> CreateScaleTriggers(IEnumerable<FunctionTrigger> triggerBindings, string hostJsonText, IDictionary<string, string> appSettings)
         {
 
@@ -138,6 +144,13 @@ namespace Kudu.Core.Functions
             return kedaScaleTriggers;
         }
 
+        internal static IEnumerable<FunctionTrigger> ParseSyncTriggerPayload(string payload)
+        {
+            var payloadJson = JObject.Parse(payload);
+            var triggers = (JArray)payloadJson["triggers"];
+            return triggers.Select(o => o.ToObject<JObject>())
+                .Select(o => new FunctionTrigger(o["functionName"].ToString(), o, o["type"].ToString()));
+        }
 
         internal static IEnumerable<FunctionTrigger> ParseFunctionJson(string functionName, JObject functionJson)
         {

--- a/Kudu.Core/Functions/SyncTriggerHandler.cs
+++ b/Kudu.Core/Functions/SyncTriggerHandler.cs
@@ -31,6 +31,7 @@ namespace Kudu.Core.Functions
             using (_tracer.Step("SyncTriggerHandler.SyncTrigger()"))
             {
                 var scaleTriggersContent = GetScaleTriggers(functionTriggersPayload);
+                Console.WriteLine("******* Getting ScaleTriggers ***");
                 if (!string.IsNullOrEmpty(scaleTriggersContent.Item2))
                 {
                     return scaleTriggersContent.Item2;
@@ -47,6 +48,7 @@ namespace Kudu.Core.Functions
                 };
 
                 await Task.Run(() => K8SEDeploymentHelper.UpdateFunctionAppTriggers(appName, scaleTriggers, buildMetadata));
+                Console.WriteLine("***** Finish the Updating App Triggers ***** ");
             }
 
             return null;
@@ -62,10 +64,9 @@ namespace Kudu.Core.Functions
                     return new Tuple<IEnumerable<ScaleTrigger>, string>(null, "Function trigger payload is null or empty.");
                 }
 
-                var triggersJson = JArray.Parse(functionTriggersPayload).Select(o => o.ToObject<JObject>());
-
-                // TODO: https://github.com/Azure/azure-functions-host/issues/7288 should change how we parse hostJsonText here.
-                scaleTriggers = KedaFunctionTriggerProvider.GetFunctionTriggers(triggersJson, string.Empty, _appSettings);
+                scaleTriggers =
+                    KedaFunctionTriggerProvider.GetFunctionTriggersFromSyncTriggerPayload(functionTriggersPayload,
+                        string.Empty, _appSettings);
                 if (!scaleTriggers.Any())
                 {
                     return new Tuple<IEnumerable<ScaleTrigger>, string>(null, "No triggers in the payload");
@@ -78,5 +79,6 @@ namespace Kudu.Core.Functions
 
             return new Tuple<IEnumerable<ScaleTrigger>, string>(scaleTriggers, null); ;
         }
+
     }
 }

--- a/Kudu.Core/Functions/SyncTriggerHandler.cs
+++ b/Kudu.Core/Functions/SyncTriggerHandler.cs
@@ -31,7 +31,6 @@ namespace Kudu.Core.Functions
             using (_tracer.Step("SyncTriggerHandler.SyncTrigger()"))
             {
                 var scaleTriggersContent = GetScaleTriggers(functionTriggersPayload);
-                Console.WriteLine("******* Getting ScaleTriggers ***");
                 if (!string.IsNullOrEmpty(scaleTriggersContent.Item2))
                 {
                     return scaleTriggersContent.Item2;
@@ -48,7 +47,6 @@ namespace Kudu.Core.Functions
                 };
 
                 await Task.Run(() => K8SEDeploymentHelper.UpdateFunctionAppTriggers(appName, scaleTriggers, buildMetadata));
-                Console.WriteLine("***** Finish the Updating App Triggers ***** ");
             }
 
             return null;

--- a/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
+++ b/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
@@ -21,27 +21,27 @@ namespace Kudu.Core.Kube
             {
                 return false;
             }
-            Console.WriteLine("**** SyncTriggerAuthenticator Started ***");
+
             //If there's no encryption key in the header return true
             if (!headers.TryGetValue(SiteTokenHeaderName, out IEnumerable<string> siteTokenHeaderValue))
             {
                 return false;
             }
-            Console.WriteLine("**** SyncTriggerAuthenticator finish TryGetValue ***");
+
             //Auth header value is null or empty return false
             var funcAppAuthToken = siteTokenHeaderValue.FirstOrDefault();
             if (string.IsNullOrEmpty(funcAppAuthToken))
             {
                 return false;
             }
-            Console.WriteLine("**** SyncTriggerAuthenticator funcAppAuthToken ***");
+
             //If there's no app name or app namespace in the header return false
             if (!headers.TryGetValue(FuncAppNameHeaderKey, out IEnumerable<string> funcAppNameHeaderValue)
                 || !headers.TryGetValue(FuncAppNamespaceHeaderKey, out IEnumerable<string> funcAppNamespaceHeaderValue))
             {
                 return false;
             }
-            Console.WriteLine("**** SyncTriggerAuthenticator TryGetValue ***");
+
             var funcAppName = funcAppNameHeaderValue.FirstOrDefault();
             var funcAppNamespace = funcAppNamespaceHeaderValue.FirstOrDefault();
             if (string.IsNullOrEmpty(funcAppName) || string.IsNullOrEmpty(funcAppNamespace))
@@ -56,7 +56,7 @@ namespace Kudu.Core.Kube
             {
                 return false;
             }
-            Console.WriteLine("**** SyncTriggerAuthenticator GetSecretContent done ***");
+
             var encryptionSecretJObject = JObject.Parse(encryptionKeySecretContent);
             var functionEncryptionKey = Base64Decode((string)encryptionSecretJObject["data"][FuncAppEncryptionKeyName]);
             if (string.IsNullOrEmpty(functionEncryptionKey))
@@ -65,7 +65,7 @@ namespace Kudu.Core.Kube
             }
 
             var decryptedToken = Decrypt(GetKeyBytes(functionEncryptionKey), funcAppAuthToken);
-            Console.WriteLine("**** SyncTriggerAuthenticator Decrypt done ***");
+
             return ValidateToken(decryptedToken);
         }
 

--- a/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
+++ b/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
@@ -51,7 +51,7 @@ namespace Kudu.Core.Kube
 
             //If the encryption key secret is null or empty in the Kubernetes - return false
             var secretProvider = new SecretProvider();
-            var encryptionKeySecretContent = await secretProvider.GetSecretContent(funcAppName + "-encryptionkey".ToLower(), funcAppNamespace);
+            var encryptionKeySecretContent = await secretProvider.GetSecretContent(funcAppName + "-encryptionkey-secrets".ToLower(), funcAppNamespace);
             if (string.IsNullOrEmpty(encryptionKeySecretContent))
             {
                 return false;

--- a/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
+++ b/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
@@ -51,7 +51,7 @@ namespace Kudu.Core.Kube
 
             //If the encryption key secret is null or empty in the Kubernetes - return false
             var secretProvider = new SecretProvider();
-            var encryptionKeySecretContent = await secretProvider.GetSecretContent(funcAppName + "-encryptionkey-secrets".ToLower(), funcAppNamespace);
+            var encryptionKeySecretContent = await secretProvider.GetSecretContent(funcAppName + "-secrets".ToLower(), funcAppNamespace);
             if (string.IsNullOrEmpty(encryptionKeySecretContent))
             {
                 return false;

--- a/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
+++ b/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
@@ -21,27 +21,27 @@ namespace Kudu.Core.Kube
             {
                 return false;
             }
-
+            Console.WriteLine("**** SyncTriggerAuthenticator Started ***");
             //If there's no encryption key in the header return true
             if (!headers.TryGetValue(SiteTokenHeaderName, out IEnumerable<string> siteTokenHeaderValue))
             {
                 return false;
             }
-
+            Console.WriteLine("**** SyncTriggerAuthenticator finish TryGetValue ***");
             //Auth header value is null or empty return false
             var funcAppAuthToken = siteTokenHeaderValue.FirstOrDefault();
             if (string.IsNullOrEmpty(funcAppAuthToken))
             {
                 return false;
             }
-
+            Console.WriteLine("**** SyncTriggerAuthenticator funcAppAuthToken ***");
             //If there's no app name or app namespace in the header return false
             if (!headers.TryGetValue(FuncAppNameHeaderKey, out IEnumerable<string> funcAppNameHeaderValue)
                 || !headers.TryGetValue(FuncAppNamespaceHeaderKey, out IEnumerable<string> funcAppNamespaceHeaderValue))
             {
                 return false;
             }
-
+            Console.WriteLine("**** SyncTriggerAuthenticator TryGetValue ***");
             var funcAppName = funcAppNameHeaderValue.FirstOrDefault();
             var funcAppNamespace = funcAppNamespaceHeaderValue.FirstOrDefault();
             if (string.IsNullOrEmpty(funcAppName) || string.IsNullOrEmpty(funcAppNamespace))
@@ -56,7 +56,7 @@ namespace Kudu.Core.Kube
             {
                 return false;
             }
-
+            Console.WriteLine("**** SyncTriggerAuthenticator GetSecretContent done ***");
             var encryptionSecretJObject = JObject.Parse(encryptionKeySecretContent);
             var functionEncryptionKey = Base64Decode((string)encryptionSecretJObject["data"][FuncAppEncryptionKeyName]);
             if (string.IsNullOrEmpty(functionEncryptionKey))
@@ -65,6 +65,7 @@ namespace Kudu.Core.Kube
             }
 
             var decryptedToken = Decrypt(GetKeyBytes(functionEncryptionKey), funcAppAuthToken);
+            Console.WriteLine("**** SyncTriggerAuthenticator Decrypt done ***");
             return ValidateToken(decryptedToken);
         }
 

--- a/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
+++ b/Kudu.Core/Kube/SyncTriggerAuthenticator.cs
@@ -64,8 +64,22 @@ namespace Kudu.Core.Kube
                 return false;
             }
 
-            var decryptedToken = Decrypt(Encoding.UTF8.GetBytes(functionEncryptionKey), funcAppAuthToken);
+            var decryptedToken = Decrypt(GetKeyBytes(functionEncryptionKey), funcAppAuthToken);
             return ValidateToken(decryptedToken);
+        }
+
+        public static byte[] GetKeyBytes(string hexOrBase64)
+        {
+            // only support 32 bytes (256 bits) key length
+            if (hexOrBase64.Length == 64)
+            {
+                return Enumerable.Range(0, hexOrBase64.Length)
+                    .Where(x => x % 2 == 0)
+                    .Select(x => Convert.ToByte(hexOrBase64.Substring(x, 2), 16))
+                    .ToArray();
+            }
+
+            return Convert.FromBase64String(hexOrBase64);
         }
 
         private static bool ValidateToken(string token)

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -681,7 +681,7 @@ namespace Kudu.Services.Web
 
                 routes.MapHttpRouteDual("sync-function-triggers-put", "operations/settriggers",
                    new { controller = "Function", action = "SyncTrigger" },
-                   new { verb = new HttpMethodRouteConstraint("PUT") });
+                   new { verb = new HttpMethodRouteConstraint("POST") });
 
                 // catch all unregistered url to properly handle not found
                 // routes.MapRoute("error-404", "{*path}", new {controller = "Error404", action = "Handle"});

--- a/Kudu.Services/Function/FunctionController.cs
+++ b/Kudu.Services/Function/FunctionController.cs
@@ -39,7 +39,7 @@ namespace Kudu.Services.Function
         /// Sync triggers to the k8se function apps
         /// </summary>
         /// <returns></returns>
-        [HttpPut]
+        [HttpPost]
         public async Task<IActionResult> SyncTrigger()
         {
             try

--- a/Kudu.Services/Function/FunctionController.cs
+++ b/Kudu.Services/Function/FunctionController.cs
@@ -42,8 +42,6 @@ namespace Kudu.Services.Function
         [HttpPut]
         public async Task<IActionResult> SyncTrigger()
         {
-            Console.WriteLine("******* Sync Trigger is executing**** ");
-            _tracer.Trace("Tracer: Sync Trigger Started...");
             try
             {
                 var headers = Request.Headers.ToDictionary(a => a.Key, a => a.Value.AsEnumerable());

--- a/Kudu.Services/Function/FunctionController.cs
+++ b/Kudu.Services/Function/FunctionController.cs
@@ -42,6 +42,8 @@ namespace Kudu.Services.Function
         [HttpPut]
         public async Task<IActionResult> SyncTrigger()
         {
+            Console.WriteLine("******* Sync Trigger is executing**** ");
+            _tracer.Trace("Tracer: Sync Trigger Started...");
             try
             {
                 var headers = Request.Headers.ToDictionary(a => a.Key, a => a.Value.AsEnumerable());

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -168,6 +168,73 @@ namespace Kudu.Tests.Core.Function
         }
 
         [Fact]
+        public void ConversionFromSyncTriggerPayloadToFunctionTrigger()
+        {
+            var inputPayload = @"
+{
+    ""triggers"": [
+        {
+            ""name"": ""myQueueItem"",
+            ""type"": ""queueTrigger"",
+            ""direction"": ""in"",
+            ""queueName"": ""js-queue-items"",
+            ""connection"": ""AzureWebJobsStorage"",
+            ""functionName"": ""QueueTrigger""
+        }
+    ],
+    ""functions"": [
+        {
+            ""name"": ""QueueTrigger"",
+            ""script_root_path_href"": ""https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/home/site/wwwroot/QueueTrigger/"",
+            ""script_href"": ""https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/home/site/wwwroot/QueueTrigger/index.js"",
+            ""config_href"": ""https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/home/site/wwwroot/QueueTrigger/function.json"",
+            ""test_data_href"": ""https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/tmp/FunctionsData/QueueTrigger.dat"",
+            ""href"": ""https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/functions/QueueTrigger"",
+            ""invoke_url_template"": null,
+            ""language"": ""node"",
+            ""config"": {
+                ""bindings"": [
+                    {
+                        ""name"": ""myQueueItem"",
+                        ""type"": ""queueTrigger"",
+                        ""direction"": ""in"",
+                        ""queueName"": ""js-queue-items"",
+                        ""connection"": ""AzureWebJobsStorage""
+                    }
+                ]
+            },
+            ""files"": null,
+            ""test_data"": """",
+            ""isDisabled"": false,
+            ""isDirect"": false,
+            ""isProxy"": false
+        }
+    ]
+}
+";
+            var expectedJObjectString = @"
+        {
+            ""name"": ""myQueueItem"",
+            ""type"": ""queueTrigger"",
+            ""direction"": ""in"",
+            ""queueName"": ""js-queue-items"",
+            ""connection"": ""AzureWebJobsStorage"",
+            ""functionName"": ""QueueTrigger""
+        }
+";
+
+            var expectedJObject = JObject.Parse(expectedJObjectString);
+            IEnumerable<KedaFunctionTriggerProvider.FunctionTrigger> results = KedaFunctionTriggerProvider.ParseSyncTriggerPayload(inputPayload);
+            var actual = results.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal("QueueTrigger", actual.FunctionName);
+            Assert.Equal("myQueueItem", actual.Binding["name"]);
+            Assert.Equal("js-queue-items", actual.Binding["queueName"]);
+            Assert.Equal("in", actual.Binding["direction"]);
+            Assert.Equal("AzureWebJobsStorage", actual.Binding["connection"]);
+        }
+
+        [Fact]
         public void UpdateFunctionTriggerBindingExpression_Replace_Expression()
         {
             IEnumerable<ScaleTrigger> triggers = new ScaleTrigger[]

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -159,7 +159,7 @@ namespace Kudu.Tests.Core.Function
                     ""authLevel"": ""anonymous""
                 }]
             }";
-
+            
             var jsonObj = JObject.Parse(jsonText);
 
             var triggers = KedaFunctionTriggerProvider.GetFunctionTriggers(new[] { jsonObj }, string.Empty, new Dictionary<string, string>());

--- a/Kudu.Tests/Core/Function/SyncTriggerHandlerTests.cs
+++ b/Kudu.Tests/Core/Function/SyncTriggerHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Kudu.Core.Functions;
 using System.Linq;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Kudu.Tests.Core.Function
@@ -7,7 +8,7 @@ namespace Kudu.Tests.Core.Function
     public class SyncTriggerHandlerTests
     {
         [Theory]
-        [InlineData("[{\"type\":\"httpTrigger\",\"methods\":[\"get\",\"post\"],\"authLevel\":\"function\",\"name\":\"req\",\"functionName\":\"Function1 - Oct152020 - 1\"},{\"type\":\"queueTrigger\",\"connection\":\"AzureWebJobsStorage\",\"queueName\":\"myqueue - 1\",\"name\":\"myQueueItem\",\"functionName\":\"Function2\"}]")]
+        [InlineData("{\"triggers\":[{\"type\":\"httpTrigger\",\"methods\":[\"get\",\"post\"],\"authLevel\":\"function\",\"name\":\"req\",\"functionName\":\"Function1 - Oct152020 - 1\"},{\"type\":\"queueTrigger\",\"connection\":\"AzureWebJobsStorage\",\"queueName\":\"myqueue - 1\",\"name\":\"myQueueItem\",\"functionName\":\"Function2\"}], \"functions\":[]}")]
         [InlineData("Invalid json")]
         [InlineData(null)]
         public void GetScaleTriggersTest(string functionTriggerPayload)


### PR DESCRIPTION
I open this PR for sharing / discussing the design of the fix. 
@pragnagopa @divyagandhisethi @ahmelsayed @cgillum 

On the Kudu Lite Side, We found these issues. 

# SSL Connection issue when we call SyncTrigger API from Azure Functions Host
That is caused when the API access to the Kubernetes API, however, the HTTP Client 
doesn't refer to the   /var/run/secrets/kubernetes.io/serviceaccount/ca.crt. 

We have three ways to fix. 
1. Add HttpClientHandler for accepting Self-Signed-Certificate 
2. Add HttpClientHandler for implementing a custom ca.cert validation.
3. Include the ca.cert when BuildServer startup   `cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /usr/local/share/ca-certificates/ && update-ca-certificates`. 

Since the ca.crt is mounted and it is possible that is updated, so that the second solution is the best, however, IMO, we can fix the first one for a while and create a new issue for 2 might be the best. 

# Wrong URL name 

The correct secret name is `functionApp-secrets`.  There are the following secrets are found. Probably, `functionApp-encryption-secrets` is old one. `functionApp-secrets` contains more information.

```
$ kubectl get secrets
tsushiququecon1901                                     Opaque                                2      4d4h
tsushiququecon1901-encryptionkey-secrets               Opaque                                1      4d4h
tsushiququecon1901-keys                                Opaque                                2      4d4h
tsushiququecon1901-secrets                             Opaque                                12     4d4h
tsushiququecon1901-token-84s6f                         kubernetes.io/service-account-token   3      4d4h
```

# token validation fails
The token validation fails, because of the Decryption using the different logic with Azure Functions Host. I change it to use the same logic as Azure Functions Host. 

# Sync Trigger Payload is not what is expected. 

Current Code, It assume that the payload will be an array of the following.

```
            string jsonText = @"
            {
                ""functionName"": ""f1"",
                ""bindings"": [{
                    ""type"": ""eventGridTrigger"",
                    ""methods"": [""GET""],
                    ""authLevel"": ""anonymous""
                }]
            }";
```

However, the sync trigger payload that is coming from Azure Functions Host is

```
{
    "triggers": [
        {
            "name": "myQueueItem",
            "type": "queueTrigger",
            "direction": "in",
            "queueName": "js-queue-items",
            "connection": "AzureWebJobsStorage",
            "functionName": "QueueTrigger"
        }
    ],
    "functions": [
        {
            "name": "QueueTrigger",
            "script_root_path_href": "https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/home/site/wwwroot/QueueTrigger/",
            "script_href": "https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/home/site/wwwroot/QueueTrigger/index.js",
            "config_href": "https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/home/site/wwwroot/QueueTrigger/function.json",
            "test_data_href": "https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/vfs/tmp/FunctionsData/QueueTrigger.dat",
            "href": "https://tsushiququecon1901.limaarcncsenv19--k53aemd.northcentralusstage.k4apps.io/admin/functions/QueueTrigger",
            "invoke_url_template": null,
            "language": "node",
            "config": {
                "bindings": [
                    {
                        "name": "myQueueItem",
                        "type": "queueTrigger",
                        "direction": "in",
                        "queueName": "js-queue-items",
                        "connection": "AzureWebJobsStorage"
                    }
                ]
            },
            "files": null,
            "test_data": "",
            "isDisabled": false,
            "isDirect": false,
            "isProxy": false
        }
    ]
}
```

I create a transformation logic simply convert from the `triggers`. 

# Durable Functions / Logic Apps Usage requires host.json information

Durable Functions / Logic Apps Transformation requires `host.json` information. It is ok for zip deploy, however, for sync trigger scenario with container app, there is no `host.json` information on the SyncTrigger payload. 
We need to update the Azure Functions Host for enabling it. 

https://github.com/Azure-App-Service/KuduLite/blob/a17a854c53ff8c392de4bb9259ba26462b6ff26c/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs#L252

# Logging
Currently, I use Console.WriteLine for the debugging. However, we should use `ITracer` However, it doesn't show something. Do we need to configure it?  I'll remove the Console.WriteLine before migrating to the PullRequest.



