### PR TITLE
Include extensions section from host.joson to create scale triggers

### DIFF
--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -144,6 +144,21 @@ namespace Kudu.Core.Functions
             return kedaScaleTriggers;
         }
 
+        internal static string ParseHostJsonPayload(string payload)
+        {
+            var payloadJson = JObject.Parse(payload);
+            var extensions = (JObject) payloadJson["extensions"];
+            if (extensions != null)
+            {
+                var hostJsonPayload = new JObject {{"extensions", extensions}};
+                return hostJsonPayload.ToString();
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
         internal static IEnumerable<FunctionTrigger> ParseSyncTriggerPayload(string payload)
         {
             var payloadJson = JObject.Parse(payload);

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -106,8 +106,8 @@ namespace Kudu.Core.Functions
         public static IEnumerable<ScaleTrigger> GetFunctionTriggers(IEnumerable<JObject> functionsJson, string hostJsonText, IDictionary<string, string> appSettings)
         {
             var triggerBindings = functionsJson
-            .Select(o => ParseFunctionJson(o["functionName"]?.ToString(), o))
-            .SelectMany(i => i);
+                .Select(o => ParseFunctionJson(o["functionName"]?.ToString(), o))
+                .SelectMany(i => i);
 
             return CreateScaleTriggers(triggerBindings, hostJsonText, appSettings);
         }

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -113,9 +113,9 @@ namespace Kudu.Core.Functions
         }
 
         public static IEnumerable<ScaleTrigger> GetFunctionTriggersFromSyncTriggerPayload(string synctriggerPayload,
-            string hostJsonText, IDictionary<string, string> appSettings)
+            IDictionary<string, string> appSettings)
         {
-            return CreateScaleTriggers(ParseSyncTriggerPayload(synctriggerPayload), hostJsonText, appSettings);
+            return CreateScaleTriggers(ParseSyncTriggerPayload(synctriggerPayload), ParseHostJsonPayload(synctriggerPayload), appSettings);
         }
 
         internal static IEnumerable<ScaleTrigger> CreateScaleTriggers(IEnumerable<FunctionTrigger> triggerBindings, string hostJsonText, IDictionary<string, string> appSettings)

--- a/Kudu.Core/Functions/SyncTriggerHandler.cs
+++ b/Kudu.Core/Functions/SyncTriggerHandler.cs
@@ -64,7 +64,7 @@ namespace Kudu.Core.Functions
 
                 scaleTriggers =
                     KedaFunctionTriggerProvider.GetFunctionTriggersFromSyncTriggerPayload(functionTriggersPayload,
-                        string.Empty, _appSettings);
+                         _appSettings);
                 if (!scaleTriggers.Any())
                 {
                     return new Tuple<IEnumerable<ScaleTrigger>, string>(null, "No triggers in the payload");

--- a/Kudu.Tests/Core/Function/SyncTriggerHandlerTests.cs
+++ b/Kudu.Tests/Core/Function/SyncTriggerHandlerTests.cs
@@ -1,5 +1,8 @@
-﻿using Kudu.Core.Functions;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Kudu.Core.Functions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -23,6 +26,30 @@ namespace Kudu.Tests.Core.Function
             {
                 Assert.True(scaleTriggers != null && scaleTriggers.Item1 != null && scaleTriggers.Item1.ToList<ScaleTrigger>().Count > 0);
             }
+        }
+
+        [Fact]
+        public void DurableFunctions_SyncTriggers()
+        {
+            // NOTE: Same basic inputs as KedaFunctionTriggersProviderTests.DurableFunctionsApp
+            JObject syncTriggersPayloadJson = new JObject(
+                new JProperty("extensions", JObject.Parse(@"{""durableTask"":{""hubName"":""DFTest"",""storageProvider"":{""type"":""mssql"",""connectionStringName"":""SQLDB_Connection""}}}")),
+                new JProperty("triggers", new JArray(
+                    JObject.Parse(@"{""functionName"":""f1"",""type"":""orchestrationTrigger"",""name"":""context""}"),
+                    JObject.Parse(@"{""functionName"":""f2"",""type"":""entityTrigger"",""name"":""ctx""}"),
+                    JObject.Parse(@"{""functionName"":""f3"",""type"":""activityTrigger"",""name"":""input""}"),
+                    JObject.Parse(@"{""functionName"":""f4"",""type"":""queueTrigger"",""connection"":""AzureWebjobsStorage"",""queueName"":""queue"",""name"":""queueItem""}"),
+                    JObject.Parse(@"{""functionName"":""f5"",""type"":""httpTrigger"",""methods"":[""post""],""authLevel"":""anonymous"",""name"":""req""}"))));
+
+            string serializedPayload = syncTriggersPayloadJson.ToString(Formatting.None);
+
+            var syncTriggerHandler = new SyncTriggerHandler(null, null, null);
+            (IEnumerable<ScaleTrigger> triggers, string error) = syncTriggerHandler.GetScaleTriggers(serializedPayload);
+            Assert.Null(error);
+            Assert.NotNull(triggers);
+
+            // We expect the same output as the other Durable Functions test
+            KedaFunctionTriggersProviderTests.ValidateDurableTriggers(triggers);
         }
     }
 }


### PR DESCRIPTION
Hi @cgillum 

I create a PR for enabling SyncTrigger with host.json payload according to this conversation. 
https://github.com/Azure/azure-functions-host/pull/7386

This PR is not tested, yet, however, it might be good to share which change will be required. So that you can add test for Durable Usage unit testing. 

CC @pragnagopa @divyagandhisethi 