### PR TITLE
Fix Kafka Trigger Metadata

### DIFF
--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -365,7 +365,7 @@ namespace Kudu.Core.Functions
                     break;
 
                 case TriggerTypes.Kafka:
-                    metadata["bootstrapServers"] = metadata["brokerList"];
+                    metadata["bootstrapServersFromEnv"] = metadata["brokerList"];
                     metadata.Remove("brokerList");
                     metadata.Remove("protocol");
                     metadata.Remove("authenticationMode");


### PR DESCRIPTION
This PR enable to  unblock the basic usage of the kafka. 
BrokerList is configured as AppSettings. 