### PR TITLE
Migrate netcoreapp3.1 and ILogger

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 3.1.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,25 @@
+name: Pull Request Validation for feature/k8se
+
+on:
+  push:
+    branches: [ feature/k8se ]
+  pull_request:
+    branches: [ feature/k8se ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Kudu.Console/Kudu.Console.csproj
+++ b/Kudu.Console/Kudu.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <AssemblyName>kudu</AssemblyName>
   </PropertyGroup>

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <PropertyGroup>

--- a/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
@@ -206,6 +206,10 @@ namespace Kudu.Core.Deployment
                     {
                         Version = "2.1";
                     }
+                    else if (Version == "3.0")
+                    {
+                        Version = "3.1";
+                    }
 
                     OryxArgumentsHelper.AddLanguageVersion(args, Version);
                     break;
@@ -251,10 +255,9 @@ namespace Kudu.Core.Deployment
             {
                 OryxArgumentsHelper.AddPythonVirtualEnv(args, VirtualEnv);
             }
+            // OryxArgumentsHelper.AddDebugLog(args);
 
-            OryxArgumentsHelper.AddDebugLog(args);
-
-            return args.ToString();
+           return args.ToString();
         }
 
         public bool SkipKuduSync { get; set; }

--- a/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
+++ b/Kudu.Core/Deployment/Oryx/OryxBuildConstants.cs
@@ -22,7 +22,7 @@ namespace Kudu.Core.Deployment.Oryx
         {
             public static readonly string Node = "8.15";
             public static readonly string Python = "3.6";
-            public static readonly string Dotnet = "2.2";
+            public static readonly string Dotnet = "3.1";
             public static readonly string PHP = "7.3";
         }
 

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <PropertyGroup>

--- a/Kudu.Core/SourceControl/Git/KnownEnvironment.cs
+++ b/Kudu.Core/SourceControl/Git/KnownEnvironment.cs
@@ -14,7 +14,7 @@ namespace Kudu.Core.SourceControl.Git
         // Command to launch the post receive hook
         // CORE NOTE modified the script to run "dotnet," assuming EXEPATH points
         // to a framework-dependent Core app.
-        public static string KUDUCOMMAND = "benv dotnet=2.2 dotnet \"$" + EXEPATH + "\" " +
+        public static string KUDUCOMMAND = "benv dotnet=3-lts dotnet \"$" + EXEPATH + "\" " +
                                            "\"$" + APPPATH + "\" " +
                                            "\"$" + MSBUILD + "\" " +
                                            "\"$" + DEPLOYER + "\"";

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -26,14 +26,13 @@
     <PackageReference Include="AspNetCore.RouteAnalyzer" Version="0.5.3" />
     <PackageReference Include="KubernetesClient" Version="1.5.25" />
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Proxy" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="XmlSettings" Version="0.1.3" />
-    <PackageReference Include="System.Runtime.Caching" Version="0.1.3" />
+    <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
   </ItemGroup>
   <Target Name="_IncludePrePublishGeneratedContent" BeforeTargets="GetCopyToPublishDirectoryItems" Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true' " />
   <ItemGroup>

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <!-- Supressing Net Core migration warnings-->

--- a/Kudu.Services.Web/KuduWebUtil.cs
+++ b/Kudu.Services.Web/KuduWebUtil.cs
@@ -220,12 +220,12 @@ namespace Kudu.Services.Web
                 {
                     if(isRunningOnAzure)
                     {
-                        FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("/usr/bin/mono", "benv dotnet=2.2 dotnet"));
+                        FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("/usr/bin/mono", "benv dotnet=3-lts dotnet"));
                     }
                 }
                 else if(!fileText.Contains("benv") && fileText.Contains("dotnet") && isRunningOnAzure)
                 {
-                    FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("dotnet", "benv dotnet=2.2 dotnet"));
+                    FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("dotnet", "benv dotnet=3-lts dotnet"));
                 }
                 
             }

--- a/Kudu.Services.Web/KuduWebUtil.cs
+++ b/Kudu.Services.Web/KuduWebUtil.cs
@@ -299,7 +299,7 @@ namespace Kudu.Services.Web
         /// Returns a specified environment configuration as the current webapp's
         /// default configuration during the runtime.
         /// </summary>
-        internal static IEnvironment GetEnvironment(IHostingEnvironment hostingEnvironment,
+        internal static IEnvironment GetEnvironment(IWebHostEnvironment hostingEnvironment,
             IDeploymentSettingsManager settings = null,
             HttpContext httpContext = null)
         {

--- a/Kudu.Services.Web/Program.cs
+++ b/Kudu.Services.Web/Program.cs
@@ -4,6 +4,7 @@ using log4net;
 using log4net.Config;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Kudu.Services.Web
 {
@@ -18,6 +19,11 @@ namespace Kudu.Services.Web
 
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .ConfigureLogging(logging =>
+                {
+                    logging.AddConsole();
+                    logging.AddEventSourceLogger();
+                })
                 .UseKestrel(options => { options.Limits.MaxRequestBodySize = null; })
                 .UseStartup<Startup>();
     }

--- a/Kudu.Services.Web/Properties/launchSettings.json
+++ b/Kudu.Services.Web/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "K8SE_BUILD_SERVICE": "yes",
-        "HOME": "C:\\work\\function-apps\\HttpFunApp1\\bin\\Debug\\netcoreapp2.2",
+        "HOME": "C:\\work\\function-apps\\HttpFunApp1\\bin\\Debug\\netcoreapp3.1",
         "ASPNETCORE_ENVIRONMENT": "Production"
       },
       "applicationUrl": "http://0.0.0.0:16018/"
@@ -22,6 +22,10 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
+        "BUILD_FLAGS": "UseExpressBuild",
+        "ENABLE_ORYX_BUILD": "true",
+        "K8SE_BUILD_SERVICE": "true",
+        "HOME": "C:\\repos\\wwwroot",
         "ASPNETCORE_ENVIRONMENT": "Production"
       },
       "applicationUrl": "http://0.0.0.0:16018/"

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Net;
-using System.Net.Http.Formatting;
 using System.Reflection;
 using AspNetCore.RouteAnalyzer;
 using Kudu.Contracts;
@@ -97,8 +96,6 @@ namespace Kudu.Services.Web
 
             services.AddMvcCore()
                 .AddRazorPages()
-                .AddJsonFormatters()
-                .AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver())
                 .AddApplicationPart(kuduServicesAssembly).AddControllersAsServices()
                 .AddApiExplorer();
 

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -46,17 +46,20 @@ using Kudu.Services.Web.Services;
 using Kudu.Core.K8SE;
 using System.Net.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
 
 namespace Kudu.Services.Web
 {
     public class Startup
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IWebHostEnvironment _hostingEnvironment;
         private IEnvironment _webAppRuntimeEnvironment;
         private IDeploymentSettingsManager _noContextDeploymentsSettingsManager;
         private static readonly ServerConfiguration ServerConfiguration = new ServerConfiguration();
 
-        public Startup(IConfiguration configuration, IHostingEnvironment hostingEnvironment)
+        public Startup(IConfiguration configuration, IWebHostEnvironment hostingEnvironment)
         {
             Console.WriteLine(@"Startup : " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
             Configuration = configuration;
@@ -101,7 +104,7 @@ namespace Kudu.Services.Web
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info {Title = "Kudu API Docs"});
+                c.SwaggerDoc("v1", new OpenApiInfo {Title = "Kudu API Docs"});
                 // Setting the comments path for the Swagger JSON and UI.
                 var xmlFile = $"Kudu.Services.xml";
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
@@ -316,8 +319,8 @@ namespace Kudu.Services.Web
             Console.WriteLine(@"Configure : " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
 
             KuduWebUtil.MigrateToNetCorePatch(_webAppRuntimeEnvironment);
-
-            if (_hostingEnvironment.IsDevelopment())
+            
+            if (HostEnvironmentEnvExtensions.IsDevelopment(_hostingEnvironment))
             {
                 app.UseDeveloperExceptionPage();
             }

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -94,8 +94,8 @@ namespace Kudu.Services.Web
             // Kudu.Services contains all the Controllers 
             var kuduServicesAssembly = Assembly.Load("Kudu.Services");
 
-            services.AddMvcCore()
-                .AddRazorPages()
+            services.AddMvcCore(options => options.EnableEndpointRouting = false)
+                .AddRazorPages().AddMvcOptions(options => options.EnableEndpointRouting = false)
                 .AddApplicationPart(kuduServicesAssembly).AddControllersAsServices()
                 .AddApiExplorer();
 

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -315,8 +315,6 @@ namespace Kudu.Services.Web
         {
             Console.WriteLine(@"Configure : " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
 
-            loggerFactory.AddEventSourceLogger();
-
             KuduWebUtil.MigrateToNetCorePatch(_webAppRuntimeEnvironment);
 
             if (_hostingEnvironment.IsDevelopment())
@@ -394,8 +392,6 @@ namespace Kudu.Services.Web
             //var configuration = kernel.Get<IServerConfiguration>();
             //GlobalConfiguration.Configuration.Formatters.Clear();
             //GlobalConfiguration.Configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
-
-            var jsonFormatter = new JsonMediaTypeFormatter();
 
 
             // CORE TODO concept of "deprecation" in routes for traces, Do we need this for linux ?

--- a/Kudu.Services/DebugExtension/DebugExtensionMiddleware.cs
+++ b/Kudu.Services/DebugExtension/DebugExtensionMiddleware.cs
@@ -51,7 +51,7 @@ namespace Kudu.Services.TunnelServer
         {
             if (loggerFactory == null)
             {
-                loggerFactory = new LoggerFactory();
+                loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
                 string level = Environment.GetEnvironmentVariable("APPSVC_TUNNEL_VERBOSITY");
                 LogLevel logLevel = LogLevel.Information;
@@ -76,9 +76,9 @@ namespace Kudu.Services.TunnelServer
                     }
                     Console.WriteLine("Setting LogLevel to " + level);
                 }
-
-                loggerFactory.AddConsole(logLevel);
             }
+
+            
 
             if (_logger == null)
             {

--- a/Kudu.Services/DebugExtension/InstanceController.cs
+++ b/Kudu.Services/DebugExtension/InstanceController.cs
@@ -1,7 +1,6 @@
 ﻿using Kudu.Core.K8SE;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Caching.Memory;
 using System;
 using System.Collections.Generic;

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -372,10 +372,10 @@ namespace Kudu.Services.Performance
         
         private void DisableResponseBuffering(HttpContext context)
         {
-            IHttpBufferingFeature bufferingFeature = context.Features.Get<IHttpBufferingFeature>();
+            IHttpResponseBodyFeature bufferingFeature = context.Features.Get<IHttpResponseBodyFeature>();
             if (bufferingFeature != null)
             {
-                bufferingFeature.DisableResponseBuffering();
+                bufferingFeature.DisableBuffering();
             }
         }
         

--- a/Kudu.Services/Function/FunctionController.cs
+++ b/Kudu.Services/Function/FunctionController.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Remotion.Linq.Parsing.Structure.IntermediateModel;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Kudu.Services/Infrastructure/FileCallbackResult.cs
+++ b/Kudu.Services/Infrastructure/FileCallbackResult.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <PropertyGroup>
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kudu.Contracts\Kudu.Contracts.csproj" />

--- a/Kudu.Services/Zip/ZipController.cs
+++ b/Kudu.Services/Zip/ZipController.cs
@@ -2,7 +2,6 @@
 using Kudu.Core;
 using Kudu.Services.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Internal;
 using System;
 using System.IO.Abstractions;
 using System.IO.Compression;

--- a/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsAppServiceTests.cs
+++ b/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsAppServiceTests.cs
@@ -28,7 +28,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
 
         [Theory]
         [InlineData("NODE", "8.15", true, false, BuildOptimizationsFlags.CompressModules)]
-        [InlineData("PYTHON", "3.6", true, false, BuildOptimizationsFlags.None)]
+        [InlineData("PYTHON", "3.6", true, false, BuildOptimizationsFlags.CompressModules)]
         [InlineData("PHP", "7.3", true, false, BuildOptimizationsFlags.None)]
         [InlineData("DOTNETCORE", "2.2", true, true, BuildOptimizationsFlags.UseTempDirectory)]
         public void ArgumentPropertyTest(string language, string version,
@@ -51,13 +51,13 @@ namespace Kudu.Tests.Core.Deployment.Oryx
 
         [Theory]
         [InlineData("NODE", "8.12",
-            "oryx build OutputPath -o OutputPath --platform nodejs --platform-version 8.12 -i BuildTempPath -p compress_node_modules=tar-gz")]
+            "oryx build RepositoryPath -o BuildTempPath --platform nodejs -i BuildTempPath -p compress_node_modules=tar-gz")]
         [InlineData("PYTHON", "3.6",
-            "oryx build OutputPath -o OutputPath --platform python --platform-version 3.6 -p virtualenv_name=antenv3.6")]
+            "oryx build RepositoryPath -o BuildTempPath --platform python --platform-version 3.6 -i BuildTempPath -p compress_virtualenv=tar-gz -p virtualenv_name=antenv3.6")]
         [InlineData("PHP", "7.3",
-            "oryx build OutputPath -o OutputPath --platform php --platform-version 7.3")]
-        [InlineData("DOTNETCORE", "2.2",
-            "oryx build RepositoryPath -o OutputPath --platform dotnet --platform-version 2.2 -i BuildTempPath")]
+            "oryx build OutputPath -o OutputPath --platform php")]
+        [InlineData("DOTNETCORE", "3.1",
+            "oryx build RepositoryPath -o OutputPath --platform dotnet --platform-version 3.1 -i BuildTempPath")]
         public void CommandGenerationTest(string language, string version, string expectedCommand)
         {
             var mockedEnvironment = new Dictionary<string, string>()
@@ -128,15 +128,15 @@ namespace Kudu.Tests.Core.Deployment.Oryx
             {
                 IOryxArguments args = new AppServiceOryxArguments(TestMockedEnvironment.GetMockedEnvironment());
                 string command = args.GenerateOryxBuildCommand(mockedContext, TestMockedEnvironment.GetMockedEnvironment());
-                Assert.Equal("oryx build OutputPath -o OutputPath --platform nodejs --platform-version 8.12 -i BuildTempPath -p compress_node_modules=zip",
+                Assert.Equal("oryx build RepositoryPath -o BuildTempPath --platform nodejs -i BuildTempPath",
                     args.GenerateOryxBuildCommand(mockedContext, TestMockedEnvironment.GetMockedEnvironment()));
             }
         }
 
         [Theory]
-        [InlineData("2.7", "oryx build OutputPath -o OutputPath --platform python --platform-version 2.7 -p virtualenv_name=antenv2.7")]
-        [InlineData("3.6", "oryx build OutputPath -o OutputPath --platform python --platform-version 3.6 -p virtualenv_name=antenv3.6")]
-        [InlineData("3.7", "oryx build OutputPath -o OutputPath --platform python --platform-version 3.7 -p virtualenv_name=antenv")]
+        [InlineData("2.7", "oryx build RepositoryPath -o BuildTempPath --platform python --platform-version 2.7 -i BuildTempPath -p compress_virtualenv=tar-gz -p virtualenv_name=antenv2.7")]
+        [InlineData("3.6", "oryx build RepositoryPath -o BuildTempPath --platform python --platform-version 3.6 -i BuildTempPath -p compress_virtualenv=tar-gz -p virtualenv_name=antenv3.6")]
+        [InlineData("3.7", "oryx build RepositoryPath -o BuildTempPath --platform python --platform-version 3.7 -i BuildTempPath -p compress_virtualenv=tar-gz -p virtualenv_name=antenv")]
         public void PythonVirtualEnvironmentNamingTest(string version, string expectedCommand)
         {
             var mockedEnvironment = new Dictionary<string, string>()
@@ -231,7 +231,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
             {
                 IOryxArguments args = new AppServiceOryxArguments(TestMockedEnvironment.GetMockedEnvironment());
                 string command = args.GenerateOryxBuildCommand(mockedContext, TestMockedEnvironment.GetMockedEnvironment());
-                Assert.Equal("oryx build  -o  --platform python --platform-version 3.6 -p virtualenv_name=antenv3.6",
+                Assert.Equal("oryx build RepositoryPath -o BuildTempPath --platform python --platform-version 3.6 -i BuildTempPath -p compress_virtualenv=tar-gz -p virtualenv_name=antenv3.6",
                     args.GenerateOryxBuildCommand(mockedContext, TestMockedEnvironment.GetMockedEnvironment()));
             }
         }

--- a/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsAppServiceTests.cs
+++ b/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsAppServiceTests.cs
@@ -30,7 +30,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
         [InlineData("NODE", "8.15", true, false, BuildOptimizationsFlags.CompressModules)]
         [InlineData("PYTHON", "3.6", true, false, BuildOptimizationsFlags.CompressModules)]
         [InlineData("PHP", "7.3", true, false, BuildOptimizationsFlags.None)]
-        [InlineData("DOTNETCORE", "2.2", true, true, BuildOptimizationsFlags.UseTempDirectory)]
+        [InlineData("DOTNETCORE", "3.1", true, true, BuildOptimizationsFlags.UseTempDirectory)]
         public void ArgumentPropertyTest(string language, string version,
             bool expectedRunOryxBuild, bool expectedSkipKuduSync, BuildOptimizationsFlags expectedFlags)
         {

--- a/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsFactoryTests.cs
+++ b/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsFactoryTests.cs
@@ -110,6 +110,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
             }
         }
 
+        // TODO check if it is proper change
         [Fact]
         public void BuildCommandForLinuxConsumptionFunctionApp()
         {
@@ -123,7 +124,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
             {
                 IOryxArguments args = OryxArgumentsFactory.CreateOryxArguments(TestMockedEnvironment.GetMockedEnvironment());
                 string command = args.GenerateOryxBuildCommand(deploymentContext, TestMockedEnvironment.GetMockedEnvironment());
-                Assert.Equal(@"oryx build repositorypath -o repositorypath", command);
+                Assert.Equal(@"oryx build repositorypath -o ", command);
             }
         }
 

--- a/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsFunctionAppTests.cs
+++ b/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsFunctionAppTests.cs
@@ -57,7 +57,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
         [InlineData("PHP",
             "oryx build OutputPath -o OutputPath --platform php --platform-version 7.3 -i BuildTempPath")]
         [InlineData("DOTNET",
-            "oryx build OutputPath -o OutputPath --platform dotnet --platform-version 2.2 -i BuildTempPath")]
+            "oryx build OutputPath -o OutputPath --platform dotnet --platform-version 3.1 -i BuildTempPath")]
         public void CommandGenerationTest(string functions_worker_runtime, string expected_command)
         {
             var mockedEnvironment = new Dictionary<string, string>()

--- a/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsLinuxConsumptionFunctionAppTests.cs
+++ b/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsLinuxConsumptionFunctionAppTests.cs
@@ -8,6 +8,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
     [Collection("MockedEnvironmentVariablesCollection")]
     public class OryxArgumentsLinuxConsumptionFunctionAppTests
     {
+        // TODO check if it is proper change
         [Fact]
         public void DefaultTest()
         {
@@ -23,7 +24,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
                 OutputPath = "OutputPath"
             };
             string command = args.GenerateOryxBuildCommand(mockedContext, TestMockedEnvironment.GetMockedEnvironment());
-            Assert.Equal("oryx build RepositoryPath -o RepositoryPath", command);
+            Assert.Equal("oryx build RepositoryPath -o OutputPath", command);
         }
 
         [Theory]
@@ -48,16 +49,16 @@ namespace Kudu.Tests.Core.Deployment.Oryx
             }
         }
 
+        // TODO Check if this is the proper change.
         [Theory]
         [InlineData("NODE",
-            "oryx build RepositoryPath -o RepositoryPath --platform nodejs --platform-version 8.15")]
+            "oryx build RepositoryPath -o OutputPath --platform nodejs --platform-version 8.15")]
         [InlineData("PYTHON",
-            "oryx build RepositoryPath -o RepositoryPath --platform python --platform-version 3.6 " +
-            "-p packagedir=.python_packages\\lib\\python3.6\\site-packages")]
+            "oryx build RepositoryPath -o OutputPath --platform python --platform-version 3.6 -p packagedir=.python_packages\\lib\\python3.6\\site-packages")]
         [InlineData("PHP",
-            "oryx build RepositoryPath -o RepositoryPath --platform php --platform-version 7.3")]
+            "oryx build RepositoryPath -o OutputPath --platform php --platform-version 7.3")]
         [InlineData("DOTNET",
-            "oryx build RepositoryPath -o RepositoryPath --platform dotnet --platform-version 2.2")]
+            "oryx build RepositoryPath -o OutputPath --platform dotnet --platform-version 2.2")]
         public void CommandGenerationTest(string functions_worker_runtime, string expected_command)
         {
             var mockedEnvironment = new Dictionary<string, string>()

--- a/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsLinuxConsumptionFunctionAppTests.cs
+++ b/Kudu.Tests/Core/Deployment/Oryx/OryxArgumentsLinuxConsumptionFunctionAppTests.cs
@@ -58,7 +58,7 @@ namespace Kudu.Tests.Core.Deployment.Oryx
         [InlineData("PHP",
             "oryx build RepositoryPath -o OutputPath --platform php --platform-version 7.3")]
         [InlineData("DOTNET",
-            "oryx build RepositoryPath -o OutputPath --platform dotnet --platform-version 2.2")]
+            "oryx build RepositoryPath -o OutputPath --platform dotnet --platform-version 3.1")]
         public void CommandGenerationTest(string functions_worker_runtime, string expected_command)
         {
             var mockedEnvironment = new Dictionary<string, string>()

--- a/Kudu.Tests/Kudu.Tests.csproj
+++ b/Kudu.Tests/Kudu.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Currently, the app is written against netcoreapp2.2 that is no longer supported. 
@pragnagopa 

https://github.com/Azure-App-Service/KuduLite/issues/202

I start this PR for discussing the design. 

The process might be the following, however, I need to learn more to validate it. 

- [x] Update netcoreapp3.1 with removing all the errors
- [x] Run CI to see if the all test works correctly (How can we run the CI? @sanchitmehta do you know ?)
- [x] Test with k4apps (By performing zip deploy)
- [ ] Remove unnecessary classes. (e.g. DebugExtensionMiddleWares.cs looks no reference)
- [ ] Enable Console Logging for ASP.NET
- [ ] Remove ITracer and migrate to ILogger
- [ ] Adding more logs for enable debugging on the Lima