### PR TITLE
Fix post-receive hook when migrating from dynamic to normal kudu in 2.2

### DIFF
--- a/Kudu.Services.Web/KuduWebUtil.cs
+++ b/Kudu.Services.Web/KuduWebUtil.cs
@@ -230,6 +230,10 @@ namespace Kudu.Services.Web
                     {
                         FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("dotnet", "benv dotnet=2.2 dotnet"));
                     }
+                    else if(!fileText.Contains("dotnet") && fileText.Contains("$KUDU_EXE") && isRunningOnAzure)
+                    {
+                        FileSystemHelpers.WriteAllText(gitPostReceiveHookFile, fileText.Replace("$KUDU_EXE", "benv dotnet=2.2 dotnet $KUDU_EXE"));
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Dynamic kudu is on 3.1 while normal kudu is on 2.2.