### PR TITLE
Fixing GetArticfactURLFromARMJSON for onedeploy

### DIFF
--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -432,8 +432,8 @@ namespace Kudu.Services.Deployment
             {
                 try
                 {
-                    // ARM template should have properties field and a packageUri field inside the properties field.
-                    string packageUri = requestObject.Value<JObject>("properties").Value<string>("packageUri");
+                    // ARM template should have properties field and a packageUri field inside the properties field.                   
+                    string packageUri = requestObject.Value<JObject>("properties") != null ? requestObject.Value<JObject>("properties").Value<string>("packageUri") : requestObject.Value<string>("packageUri");
                     if (string.IsNullOrEmpty(packageUri))
                     {
                         throw new ArgumentException("Invalid Url in the JSON request");
@@ -513,7 +513,7 @@ namespace Kudu.Services.Deployment
                         FileSystemHelpers.RemoveUnixSymlink(nodeModulesSymlinkFile, TimeSpan.FromSeconds(5));
                     }
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     // best effort
                 }


### PR DESCRIPTION
In case of ARM call OneDeploy API passes requestJson as requestJson.Value<JObject>("properties"), and that's causing GetArticfactURLFromARMJSON throw System.NullReferenceException exception when trying to access packageUri.