### PR TITLE
Fix version conflicts caused by PR#184

### DIFF
--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.25.2" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Mercurial.Net" Version="1.1.1.607" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="0.1.78-alpha" />
     <PackageReference Include="ncrontab" Version="3.3.0" />
     <PackageReference Include="NuGet.Protocol" Version="4.8.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.192" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Include="XmlSettings" Version="0.1.3" />

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.Proxy" Version="4.2.0" />
     <PackageReference Include="AspNetCore.RouteAnalyzer" Version="0.5.3" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump log4net from 2.0.8 to 2.0.10 in /Kudu.Services.Web. [(PR#184)](https://github.com/Azure-App-Service/KuduLite/pull/184).
Hope this fix can help you.

Best regards,
sucrose