### PR TITLE
Translate Cosmos DB trigger binding to ScaledObject metadata

### DIFF
--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -249,34 +249,18 @@ namespace Kudu.Core.Functions
                 throw new ArgumentNullException(nameof(triggerType));
             }
 
-            triggerType = triggerType.ToLower();
-
-            switch (triggerType)
+            return triggerType.ToLower() switch
             {
-                case TriggerTypes.AzureStorageQueue:
-                    return "azure-queue";
-
-                case TriggerTypes.Kafka:
-                    return "kafka";
-
-                case TriggerTypes.AzureBlobStorage:
-                    return "azure-blob";
-
-                case TriggerTypes.AzureServiceBus:
-                    return "azure-servicebus";
-
-                case TriggerTypes.AzureEventHubs:
-                    return "azure-eventhub";
-
-                case TriggerTypes.RabbitMq:
-                    return "rabbitmq";
-
-                case TriggerTypes.Http:
-                    return "httpTrigger";
-
-                default:
-                    return string.Empty;
-            }
+                TriggerTypes.AzureBlobStorage => "azure-blob",
+                TriggerTypes.AzureCosmosDb => "azure-cosmosdb",
+                TriggerTypes.AzureEventHubs => "azure-eventhub",
+                TriggerTypes.AzureServiceBus => "azure-servicebus",
+                TriggerTypes.AzureStorageQueue => "azure-queue",
+                TriggerTypes.Http => "httpTrigger",
+                TriggerTypes.Kafka => "kafka",
+                TriggerTypes.RabbitMq => "rabbitmq",
+                _ => string.Empty,
+            };
         }
 
         internal static bool TryGetDurableKedaTrigger(string hostJsonText, out ScaleTrigger scaleTrigger)
@@ -404,6 +388,29 @@ namespace Kudu.Core.Functions
                     metadata["hostFromEnv"] = metadata["connectionStringSetting"];
                     metadata.Remove("connectionStringSetting");
                     break;
+
+                case TriggerTypes.AzureCosmosDb:
+
+                    // Following code supports CosmosDBTrigger binding fields as defined in both v3 and v4 versions of
+                    // Microsoft.Azure.WebJobs.Extensions.CosmosDB package. Also, it places default values for optional
+                    // fields to match the logic in extension library (https://github.com/Azure/azure-webjobs-sdk-extensions).
+
+                    const string DefaultConnectionStringName = "CosmosDB";
+                    const string DefaultLeaseCollectionName = "leases";
+
+                    metadata = new Dictionary<string, string>
+                    {
+                        // Not including 'scalerAddress' field since it can vary with environment.
+                        ["connection"] = metadata.GetValue("connection", "connectionStringSetting") ?? DefaultConnectionStringName,
+                        ["databaseId"] = metadata.GetValue("databaseName"),
+                        ["containerId"] = metadata.GetValue("containerName", "collectionName"),
+                        ["leaseConnection"] = metadata.GetValue("leaseConnection", "connection", "leaseConnectionStringSetting", "connectionStringSetting") ?? DefaultConnectionStringName,
+                        ["leaseDatabaseId"] = metadata.GetValue("leaseDatabaseName", "databaseName"),
+                        ["leaseContainerId"] = metadata.GetValue("leaseContainerName", "leaseCollectionName") ?? DefaultLeaseCollectionName,
+                        ["processorName"] = metadata.GetValue("leaseContainerPrefix", "leaseCollectionPrefix") ?? string.Empty,
+                    };
+
+                    break;
             }
 
             // Clean-up for all triggers
@@ -413,6 +420,12 @@ namespace Kudu.Core.Functions
 
             metadata["functionName"] = functionName;
             return metadata;
+        }
+
+        private static string GetValue(this IDictionary<string, string> dictionary, params string[] keys)
+        {
+            string containedKey = keys.FirstOrDefault(key => dictionary.ContainsKey(key));
+            return containedKey != null ? dictionary[containedKey] : null;
         }
 
         internal class FunctionTrigger
@@ -432,12 +445,13 @@ namespace Kudu.Core.Functions
         static class TriggerTypes
         {
             public const string AzureBlobStorage = "blobtrigger";
+            public const string AzureCosmosDb = "cosmosdbtrigger";
             public const string AzureEventHubs = "eventhubtrigger";
             public const string AzureServiceBus = "servicebustrigger";
             public const string AzureStorageQueue = "queuetrigger";
+            public const string Http = "httptrigger";
             public const string Kafka = "kafkatrigger";
             public const string RabbitMq = "rabbitmqtrigger";
-            public const string Http = "httptrigger";
         }
     }
 }

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -106,6 +106,103 @@ namespace Kudu.Tests.Core.Function
             }
         }
 
+        [Fact]
+        public void PopulateMetadataDictionary_CosmosDbTriggerV4()
+        {
+            // Test handling for the trigger defined in Cosmos DB WebJobs extension 4.0.0.
+            var bindingJObject = new JObject
+            {
+                ["type"] = "cosmosDbTrigger",
+                ["name"] = "myBinding",
+                ["connection"] = "myConnection",
+                ["databaseName"] = "myDatabaseName",
+                ["containerName"] = "myContainerName",
+                ["leaseConnection"] = "myLeaseConnection",
+                ["leaseDatabaseName"] = "myLeaseDatabaseName",
+                ["leaseContainerName"] = "myLeaseContainerName",
+                ["leaseContainerPrefix"] = "myLeaseContainerPrefix",
+            };
+
+            IDictionary<string, string> metadata = KedaFunctionTriggerProvider.PopulateMetadataDictionary(bindingJObject, "myFunction");
+
+            Assert.NotNull(metadata);
+            Assert.NotEmpty(metadata);
+
+            Assert.False(metadata.ContainsKey("type"));
+            Assert.False(metadata.ContainsKey("name"));
+
+            Assert.Equal("myConnection", metadata["connection"]);
+            Assert.Equal("myDatabaseName", metadata["databaseId"]);
+            Assert.Equal("myContainerName", metadata["containerId"]);
+            Assert.Equal("myLeaseConnection", metadata["leaseConnection"]);
+            Assert.Equal("myLeaseDatabaseName", metadata["leaseDatabaseId"]);
+            Assert.Equal("myLeaseContainerName", metadata["leaseContainerId"]);
+            Assert.Equal("myLeaseContainerPrefix", metadata["processorName"]);
+        }
+
+        [Fact]
+        public void PopulateMetadataDictionary_CosmosDbTriggerV3()
+        {
+            // Test handling for the trigger defined in Cosmos DB WebJobs extension 3.10.0.
+            var bindingJObject = new JObject
+            {
+                ["type"] = "cosmosDbTrigger",
+                ["name"] = "myBinding",
+                ["connectionStringSetting"] = "myConnectionStringSetting",
+                ["databaseName"] = "myDatabaseName",
+                ["collectionName"] = "myCollectionName",
+                ["leaseConnectionStringSetting"] = "myLeaseConnectionStringSetting",
+                ["leaseDatabaseName"] = "myLeaseDatabaseName",
+                ["leaseCollectionName"] = "myLeaseCollectionName",
+                ["leaseCollectionPrefix"] = "myLeaseCollectionPrefix",
+            };
+
+            IDictionary<string, string> metadata = KedaFunctionTriggerProvider.PopulateMetadataDictionary(bindingJObject, "myFunction");
+
+            Assert.NotNull(metadata);
+            Assert.NotEmpty(metadata);
+
+            Assert.False(metadata.ContainsKey("type"));
+            Assert.False(metadata.ContainsKey("name"));
+
+            Assert.Equal("myConnectionStringSetting", metadata["connection"]);
+            Assert.Equal("myDatabaseName", metadata["databaseId"]);
+            Assert.Equal("myCollectionName", metadata["containerId"]);
+            Assert.Equal("myLeaseConnectionStringSetting", metadata["leaseConnection"]);
+            Assert.Equal("myLeaseDatabaseName", metadata["leaseDatabaseId"]);
+            Assert.Equal("myLeaseCollectionName", metadata["leaseContainerId"]);
+            Assert.Equal("myLeaseCollectionPrefix", metadata["processorName"]);
+        }
+
+        [Fact]
+        public void PopulateMetadataDictionary_CosmosDbTriggerDefaults()
+        {
+            // Test default-value substitution if optional fields in trigger binding are not provided.
+            var bindingJObject = new JObject
+            {
+                ["type"] = "cosmosDbTrigger",
+                ["name"] = "myBinding",
+                ["databaseName"] = "myDatabaseName",
+                ["containerName"] = "myContainerName",
+            };
+
+            IDictionary<string, string> metadata = KedaFunctionTriggerProvider.PopulateMetadataDictionary(bindingJObject, "myFunction");
+
+            Assert.NotNull(metadata);
+            Assert.NotEmpty(metadata);
+
+            Assert.False(metadata.ContainsKey("type"));
+            Assert.False(metadata.ContainsKey("name"));
+
+            Assert.Equal("CosmosDB", metadata["connection"]);
+            Assert.Equal("myDatabaseName", metadata["databaseId"]);
+            Assert.Equal("myContainerName", metadata["containerId"]);
+            Assert.Equal("CosmosDB", metadata["leaseConnection"]);
+            Assert.Equal("myDatabaseName", metadata["leaseDatabaseId"]);
+            Assert.Equal("leases", metadata["leaseContainerId"]);
+            Assert.Equal(string.Empty, metadata["processorName"]);
+        }
+
          public void PopulateMetadataDictionary_KedaV1_CorrectlyPopulatesRabbitMQMetadata()
         {
             string jsonText = @"


### PR DESCRIPTION
This is best possible attempt to faithfully generate KEDA `ScaledObject` trigger metadata from Cosmos DB trigger binding. It supports the `CosmosDBTriggerAttribute` definition from both [v3.10.0](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/cosmos-v3.0.10/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs) and [v4.0.0-preview3](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/cosmos-v4.0.0-preview3/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs) of Microsoft.Azure.WebJobs.Extensions.CosmosDB library. It also takes into account default values substituted by the library if user does not provide them (examples [**1**](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/cosmos-v4.0.0-preview3/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs#L37..L38), [**2**](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/cosmos-v4.0.0-preview3/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs#L163..L169), [**3**](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/cosmos-v4.0.0-preview3/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs#L56)).

There are couple of problems with handling of trigger bindings with deploying functions on Azure Arc, that negatively impacts the translation functionality:

1. During ZIP deployment of function app, the settings should be passed as headers with name in format `appsetting_<setting-name>`. However, the envoy frontend blocks any incoming request having underscore character in its header. This prevents passing of app settings as of today. There is an ongoing work item to fix this issue.
2. Even if the app settings are taken into account, for trigger binding fields having `[AppSetting]` or `[ConnectionString]` attribute applied (for example `ConnectionStringSetting`), it won't be straightaway possible to differentiate between literal string values or references to settings, since KuduLite does not have knowledge that these are special fields.

KuduLite sets the trigger type as `azure-cosmosdb`. The app controller component in K8SE can use this information to replace the type of trigger to `external` and fill in suitable address for Cosmos DB external scaler.