### PR TITLE
StorageConnection as part of metadata for Event hub triggers

### DIFF
--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -375,6 +375,7 @@ namespace Kudu.Core.Functions
                 case TriggerTypes.AzureEventHubs:
                     metadata[ConnectionFromEnvField] = metadata[ConnectionField];
                     metadata.Remove(ConnectionField);
+                    metadata["storageConnectionFromEnv"] = metadata["storageConnection"] ?? "AzureWebJobsStorage";
                     break;
 
                 case TriggerTypes.Kafka:

--- a/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
+++ b/Kudu.Core/Functions/KedaFunctionTriggerProvider.cs
@@ -375,7 +375,7 @@ namespace Kudu.Core.Functions
                 case TriggerTypes.AzureEventHubs:
                     metadata[ConnectionFromEnvField] = metadata[ConnectionField];
                     metadata.Remove(ConnectionField);
-                    metadata["storageConnectionFromEnv"] = metadata["storageConnection"] ?? "AzureWebJobsStorage";
+                    metadata["storageConnectionFromEnv"] = metadata.ContainsKey("storageconnection") ? metadata["storageconnection"] : "AzureWebJobsStorage";
                     break;
 
                 case TriggerTypes.Kafka:

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -378,7 +378,6 @@ namespace Kudu.Tests.Core.Function
         [Fact]
         public void PopulateMetadataDictionary_EventHubsTrigger()
         {
-            // Test handling for the trigger defined in Cosmos DB WebJobs extension 4.0.0.
             var bindingJObject = new JObject
             {
                 ["type"] = "eventhubtrigger",

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -374,5 +374,26 @@ namespace Kudu.Tests.Core.Function
             Assert.Equal("$Default", metadata["ConsumerGroup"] );
             Assert.Equal("BrokerList", metadata["brokerList"]);
         }
+
+        [Fact]
+        public void PopulateMetadataDictionary_EventHubsTrigger()
+        {
+            // Test handling for the trigger defined in Cosmos DB WebJobs extension 4.0.0.
+            var bindingJObject = new JObject
+            {
+                ["type"] = "eventhubtrigger",
+                ["name"] = "myBinding",
+                ["connection"] = "myConnection",
+            };
+
+            IDictionary<string, string> metadata = KedaFunctionTriggerProvider.PopulateMetadataDictionary(bindingJObject, "myFunction");
+
+            Assert.NotNull(metadata);
+            Assert.NotEmpty(metadata);
+
+            Assert.False(metadata.ContainsKey("connection"));
+            Assert.True(metadata.ContainsKey("connectionFromEnv"));
+            Assert.True(metadata.ContainsKey("storageConnectionFromEnv"));
+        }
     }
 }


### PR DESCRIPTION
In the fix for https://github.com/kedacore/keda/issues/2363 , we have identified that the scaled object created through function apps is missing storageconnection data and KEDA is through error which leads to failure in scaling.