### PR TITLE
Support multi namespace

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -27,8 +27,6 @@ namespace Kudu
         public const string ZipExtractPath = "extracted";
         public const string ArtifactZipFileName = "artifact.zip";
 
-        public const string WindowsAppHomeDir = @"C:\repos\apps\";
-        public const string LinuxAppHomeDir = "/home/apps/";
         public const string WindowsSiteRepoDir = @"\site\repository";
         public const string LinuxSiteRepoDir = "/site/repository";
 

--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -417,7 +417,10 @@ namespace Kudu.Console
         private static IEnvironment GetEnvironment(string siteRoot)
         {
             string root = Path.GetFullPath(Path.Combine(siteRoot, ".."));
-            string appName = root.Replace("/home/apps/", "");
+            var parts = root.Split(@"/apps/");
+            string appName = parts[1];
+            parts = parts[0].Split(@"/namespace/");
+            string appNamespace = parts[1];
             var requestIdEnv = string.Format(Constants.RequestIdEnvFormat, appName);
             string requestId = System.Environment.GetEnvironmentVariable(requestIdEnv);
 
@@ -443,7 +446,8 @@ namespace Kudu.Console
             requestId,
             Path.Combine(AppContext.BaseDirectory, "KuduConsole", "kudu.dll"),
             null,
-            appName);
+            appName,
+            appNamespace);
             return env;
         }
     }

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -34,6 +34,7 @@
         bool IsOnLinuxConsumption { get; }      // e.g. True on Linux Consumption. False on App Service.
         bool IsK8SEApp { get; }
         string K8SEAppName { get;  }
+        string K8SEAppNamespace { get; }
         string K8SEAppType { get; }
     }
 }

--- a/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
+++ b/Kudu.Core/Deployment/Oryx/AppServiceOryxArguments.cs
@@ -37,7 +37,7 @@ namespace Kudu.Core.Deployment
                 this.AppName = environment.K8SEAppName;
 
                 // K8SE TODO: Inject Environment
-                var frameworkArr = K8SEDeploymentHelper.GetLinuxFxVersion(AppName);
+                var frameworkArr = K8SEDeploymentHelper.GetLinuxFxVersion(environment.K8SEAppNamespace, AppName);
                 framework = frameworkArr.Split("|")[0];
                 version = frameworkArr.Split("|")[1];
             }

--- a/Kudu.Core/Functions/IKedaAuthRefProvider.cs
+++ b/Kudu.Core/Functions/IKedaAuthRefProvider.cs
@@ -6,7 +6,7 @@ namespace Kudu.Core.Functions
 {
     public interface IKedaAuthRefProvider 
     {
-        public  IDictionary<string, string> PopulateAuthenticationRef(JToken functionBindings, string functionName);
+        public  IDictionary<string, string> PopulateAuthenticationRef(JToken functionBindings, string functionName, string functionNamespace);
 
     }
 }

--- a/Kudu.Core/Functions/SyncTriggerHandler.cs
+++ b/Kudu.Core/Functions/SyncTriggerHandler.cs
@@ -30,7 +30,8 @@ namespace Kudu.Core.Functions
         {
             using (_tracer.Step("SyncTriggerHandler.SyncTrigger()"))
             {
-                var scaleTriggersContent = GetScaleTriggers(functionTriggersPayload);
+                string appNamespace = _environment.K8SEAppNamespace;
+                var scaleTriggersContent = GetScaleTriggers(appNamespace, functionTriggersPayload);
                 if (!string.IsNullOrEmpty(scaleTriggersContent.Item2))
                 {
                     return scaleTriggersContent.Item2;
@@ -39,13 +40,13 @@ namespace Kudu.Core.Functions
                 var scaleTriggers = scaleTriggersContent.Item1;
                 string appName = _environment.K8SEAppName;
 
-                await Task.Run(() => K8SEDeploymentHelper.UpdateFunctionAppTriggers(_environment.K8SEAppNamespace, appName, scaleTriggers, null));
+                await Task.Run(() => K8SEDeploymentHelper.UpdateFunctionAppTriggers(appNamespace, appName, scaleTriggers, null));
             }
 
             return null;
         }
 
-        public Tuple<IEnumerable<ScaleTrigger>, string> GetScaleTriggers(string functionTriggersPayload)
+        public Tuple<IEnumerable<ScaleTrigger>, string> GetScaleTriggers(string functionNamespace, string functionTriggersPayload)
         {
             IEnumerable<ScaleTrigger> scaleTriggers = new List<ScaleTrigger>();
             try
@@ -56,7 +57,7 @@ namespace Kudu.Core.Functions
                 }
 
                 scaleTriggers =
-                    KedaFunctionTriggerProvider.GetFunctionTriggersFromSyncTriggerPayload(functionTriggersPayload,
+                    KedaFunctionTriggerProvider.GetFunctionTriggersFromSyncTriggerPayload(functionNamespace, functionTriggersPayload,
                          _appSettings);
                 if (!scaleTriggers.Any())
                 {

--- a/Kudu.Core/Functions/SyncTriggerHandler.cs
+++ b/Kudu.Core/Functions/SyncTriggerHandler.cs
@@ -39,7 +39,7 @@ namespace Kudu.Core.Functions
                 var scaleTriggers = scaleTriggersContent.Item1;
                 string appName = _environment.K8SEAppName;
 
-                await Task.Run(() => K8SEDeploymentHelper.UpdateFunctionAppTriggers(appName, scaleTriggers, null));
+                await Task.Run(() => K8SEDeploymentHelper.UpdateFunctionAppTriggers(_environment.K8SEAppNamespace, appName, scaleTriggers, null));
             }
 
             return null;

--- a/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
@@ -40,7 +40,7 @@ namespace Kudu.Core.Infrastructure
                 string appNamespace = environment.K8SEAppNamespace;
                 string appType = environment.K8SEAppType;
                 string buildNumber = environment.CurrId;
-                var functionTriggers = KedaFunctionTriggerProvider.GetFunctionTriggers(repositoryUrl, appName, appType, appSettings);
+                var functionTriggers = KedaFunctionTriggerProvider.GetFunctionTriggers(appNamespace, repositoryUrl, appName, appType, appSettings);
                 var buildMetadata = new BuildMetadata()
                 {
                     AppName = appName,

--- a/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
@@ -37,6 +37,7 @@ namespace Kudu.Core.Infrastructure
             if (K8SEDeploymentHelper.IsK8SEEnvironment())
             {
                 string appName = environment.K8SEAppName;
+                string appNamespace = environment.K8SEAppNamespace;
                 string appType = environment.K8SEAppType;
                 string buildNumber = environment.CurrId;
                 var functionTriggers = KedaFunctionTriggerProvider.GetFunctionTriggers(repositoryUrl, appName, appType, appSettings);
@@ -50,11 +51,11 @@ namespace Kudu.Core.Infrastructure
                 //Only for function apps functionTriggers will be non-null/non-empty
                 if (functionTriggers?.Any() == true)
                 {
-                    K8SEDeploymentHelper.UpdateFunctionAppTriggers(appName, functionTriggers, buildMetadata);
+                    K8SEDeploymentHelper.UpdateFunctionAppTriggers(appNamespace, appName, functionTriggers, buildMetadata);
                 }
                 else
                 {
-                    K8SEDeploymentHelper.UpdateBuildNumber(appName, buildMetadata);
+                    K8SEDeploymentHelper.UpdateBuildNumber(appNamespace, appName, buildMetadata);
                 }
 
                 return;

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -61,7 +61,6 @@ namespace Kudu.Core.Infrastructure
             {
                 var di = new DirectoryInfo(dirPath);
                 MoveDirectory(dirPath, Path.Combine(destDirName, di.Name));
-                Instance.Directory.Delete(dirPath, false);
             }
 
             Instance.Directory.Delete(sourceDirName, false);

--- a/Kudu.Core/K8SE/BuildCtlArgumentsHelper.cs
+++ b/Kudu.Core/K8SE/BuildCtlArgumentsHelper.cs
@@ -11,6 +11,11 @@ namespace Kudu.Core.K8SE
             args.AppendFormat("buildctl {0} ", verb);
         }
 
+        internal static void AddAppNamespaceArgument(StringBuilder args, string appNamespace)
+        {
+            args.AppendFormat(" -appNamespace {0}", appNamespace);
+        }
+
         internal static void AddAppNameArgument(StringBuilder args, string appName)
         {
             args.AppendFormat(" -appName {0}", appName);

--- a/Kudu.Core/Kube/BuildJobHelper.cs
+++ b/Kudu.Core/Kube/BuildJobHelper.cs
@@ -209,8 +209,9 @@ namespace Kudu.Core.Kube
         {
             using (tracer.Step("Create build job"))
             {
+                tracer.Trace($"==cz== appNamespace: {env.K8SEAppNamespace}, appName: {env.K8SEAppName}, podNamespace:{podNamespace}, buildJobNamePrefix: {buildJobNamePrefix}, appRoot: {appRoot}");
                 var podDeploymentName = System.Environment.GetEnvironmentVariable(SettingsKeys.PodDeploymentName);
-                var deployment = await client.ListNamespacedDeploymentAsync(podNamespace);
+                var deployment = await client.ListNamespacedDeploymentAsync(env.K8SEAppNamespace);
                 var appDeployment = deployment.Items.FirstOrDefault(n => n.Metadata.Name == env.K8SEAppName);
 
                 string hostName = new Uri(env.AppBaseUrlPrefix).Host;
@@ -245,6 +246,8 @@ namespace Kudu.Core.Kube
                 var buildJobConfigMap = System.Environment.GetEnvironmentVariable(SettingsKeys.BuildJobConfigMap);
                 var buildJobImage = System.Environment.GetEnvironmentVariable(SettingsKeys.BuildJobImage);
 
+                var secret = await client.ReadNamespacedSecretAsync($"{env.K8SEAppName}-secrets", env.K8SEAppNamespace);
+                tracer.Trace($"==cz== secret: {Convert.ToBase64String(secret.Data[Constants.SiteAuthEncryptionKey])}");
                 var job = await client.CreateNamespacedJobAsync(
                     new V1Job()
                     {
@@ -294,7 +297,7 @@ namespace Kudu.Core.Kube
                                                     new V1EnvVar
                                                     {
                                                         Name = Constants.SiteAuthEncryptionKey,
-                                                        ValueFrom = new V1EnvVarSource { SecretKeyRef = new V1SecretKeySelector{ Name = $"{env.K8SEAppName}-secrets", Key = Constants.SiteAuthEncryptionKey} }
+                                                        Value = Convert.ToBase64String(secret.Data[Constants.SiteAuthEncryptionKey]),
                                                     }
                                                 },
                                                 EnvFrom = new List<V1EnvFromSource>

--- a/Kudu.Core/Kube/BuildJobHelper.cs
+++ b/Kudu.Core/Kube/BuildJobHelper.cs
@@ -247,7 +247,7 @@ namespace Kudu.Core.Kube
                 var buildJobImage = System.Environment.GetEnvironmentVariable(SettingsKeys.BuildJobImage);
 
                 var secret = await client.ReadNamespacedSecretAsync($"{env.K8SEAppName}-secrets", env.K8SEAppNamespace);
-                tracer.Trace($"==cz== secret: {Convert.ToBase64String(secret.Data[Constants.SiteAuthEncryptionKey])}");
+                tracer.Trace($"==cz== secret: {Encoding.UTF8.GetString(secret.Data[Constants.SiteAuthEncryptionKey])}");
                 var job = await client.CreateNamespacedJobAsync(
                     new V1Job()
                     {
@@ -297,7 +297,7 @@ namespace Kudu.Core.Kube
                                                     new V1EnvVar
                                                     {
                                                         Name = Constants.SiteAuthEncryptionKey,
-                                                        Value = Convert.ToBase64String(secret.Data[Constants.SiteAuthEncryptionKey]),
+                                                        Value = Encoding.UTF8.GetString(secret.Data[Constants.SiteAuthEncryptionKey]),
                                                     }
                                                 },
                                                 EnvFrom = new List<V1EnvFromSource>

--- a/Kudu.Core/Kube/BuildJobHelper.cs
+++ b/Kudu.Core/Kube/BuildJobHelper.cs
@@ -209,7 +209,6 @@ namespace Kudu.Core.Kube
         {
             using (tracer.Step("Create build job"))
             {
-                tracer.Trace($"==cz== appNamespace: {env.K8SEAppNamespace}, appName: {env.K8SEAppName}, podNamespace:{podNamespace}, buildJobNamePrefix: {buildJobNamePrefix}, appRoot: {appRoot}");
                 var podDeploymentName = System.Environment.GetEnvironmentVariable(SettingsKeys.PodDeploymentName);
                 var deployment = await client.ListNamespacedDeploymentAsync(env.K8SEAppNamespace);
                 var appDeployment = deployment.Items.FirstOrDefault(n => n.Metadata.Name == env.K8SEAppName);
@@ -247,7 +246,6 @@ namespace Kudu.Core.Kube
                 var buildJobImage = System.Environment.GetEnvironmentVariable(SettingsKeys.BuildJobImage);
 
                 var secret = await client.ReadNamespacedSecretAsync($"{env.K8SEAppName}-secrets", env.K8SEAppNamespace);
-                tracer.Trace($"==cz== secret: {Encoding.UTF8.GetString(secret.Data[Constants.SiteAuthEncryptionKey])}");
                 var job = await client.CreateNamespacedJobAsync(
                     new V1Job()
                     {

--- a/Kudu.Services.Web/InstanceMiddleware.cs
+++ b/Kudu.Services.Web/InstanceMiddleware.cs
@@ -152,7 +152,7 @@ namespace Kudu.Services.Web
                 var remainingPath = m.Groups[4].Value;
                 Console.WriteLine(instanceId);
                 Console.WriteLine(remainingPath);
-                List<PodInstance> instances = K8SEDeploymentHelper.GetInstances(K8SEDeploymentHelper.GetAppName(context));
+                List<PodInstance> instances = K8SEDeploymentHelper.GetInstances(K8SEDeploymentHelper.GetAppNamespace(context), K8SEDeploymentHelper.GetAppName(context));
                 PodInstance instance = instances.Where(i => i.Name.Equals(instanceId, System.StringComparison.OrdinalIgnoreCase)).FirstOrDefault(); ;
 
                 // handle null, 0 instances

--- a/Kudu.Services.Web/KubeMiddleware.cs
+++ b/Kudu.Services.Web/KubeMiddleware.cs
@@ -96,7 +96,7 @@ namespace Kudu.Services.Web
             if (context.Request.Path.Value.StartsWith("/instances/", StringComparison.OrdinalIgnoreCase)
                 && context.Request.Path.Value.IndexOf("/webssh") > 0)
             {
-                List<PodInstance> instances = K8SEDeploymentHelper.GetInstances(appName);
+                List<PodInstance> instances = K8SEDeploymentHelper.GetInstances(appNamenamespace, appName);
 
                 int idx = context.Request.Path.Value.IndexOf("/webssh");
                 string instanceId = context.Request.Path.Value.Substring(0, idx).Replace("/instances/", "");

--- a/Kudu.Services.Web/KubeMiddleware.cs
+++ b/Kudu.Services.Web/KubeMiddleware.cs
@@ -46,19 +46,19 @@ namespace Kudu.Services.Web
         public async Task Invoke(HttpContext context, IEnvironment environment, IServerConfiguration serverConfig)
         {
             string appName = K8SEDeploymentHelper.GetAppName(context);
-            string appNamenamespace = K8SEDeploymentHelper.GetAppNamespace(context);
+            string appNamespace = K8SEDeploymentHelper.GetAppNamespace(context);
             string appType = K8SEDeploymentHelper.GetAppKind(context);
 
             string homeDir = "";
             string siteRepoDir = "";
             if (OSDetector.IsOnWindows())
             {
-                homeDir = Constants.WindowsAppHomeDir;
+                homeDir = PathResolver.ResolveWindowsAppHomeDir(appNamespace);
                 siteRepoDir = Constants.WindowsSiteRepoDir;
             }
             else
             {
-                homeDir = Constants.LinuxAppHomeDir;
+                homeDir = PathResolver.ResolveLinuxAppHomeDir(appNamespace);
                 siteRepoDir = Constants.LinuxSiteRepoDir;
             }
 
@@ -83,7 +83,7 @@ namespace Kudu.Services.Web
             environment.RepositoryPath = $"{homeDir}{appName}{siteRepoDir}";
 
             // Cache the App Environment for this request
-            context.Items.TryAdd("environment", GetEnvironment(homeDir, appName, null, context, appNamenamespace, appType));
+            context.Items.TryAdd("environment", GetEnvironment(homeDir, appName, null, context, appNamespace, appType));
 
             // Cache the appName for this request
             context.Items.TryAdd("appName", appName);
@@ -96,7 +96,7 @@ namespace Kudu.Services.Web
             if (context.Request.Path.Value.StartsWith("/instances/", StringComparison.OrdinalIgnoreCase)
                 && context.Request.Path.Value.IndexOf("/webssh") > 0)
             {
-                List<PodInstance> instances = K8SEDeploymentHelper.GetInstances(appNamenamespace, appName);
+                List<PodInstance> instances = K8SEDeploymentHelper.GetInstances(appNamespace, appName);
 
                 int idx = context.Request.Path.Value.IndexOf("/webssh");
                 string instanceId = context.Request.Path.Value.Substring(0, idx).Replace("/instances/", "");
@@ -135,9 +135,9 @@ namespace Kudu.Services.Web
             }
 
             // Cache the appNamenamespace for this request if it's not empty or null
-            if (!string.IsNullOrEmpty(appNamenamespace))
+            if (!string.IsNullOrEmpty(appNamespace))
             {
-                context.Items.TryAdd("appNamespace", appNamenamespace);
+                context.Items.TryAdd("appNamespace", appNamespace);
             }
 
             await _next.Invoke(context);

--- a/Kudu.Services.Web/KuduWebUtil.cs
+++ b/Kudu.Services.Web/KuduWebUtil.cs
@@ -336,23 +336,25 @@ namespace Kudu.Services.Web
             HttpContext httpContext = null)
         {
             string appName = null;
-            string appNamenamespace = null;
+            // default to build service pod namespace
+            string appNamespace = System.Environment.GetEnvironmentVariable(SettingsKeys.PodNamespace);
             string appType = null;
             var root = PathResolver.ResolveRootPath();
+            root = Path.Combine(root, "namespace", appNamespace);
             if (httpContext != null)
             {
                 appName = K8SEDeploymentHelper.GetAppName(httpContext);
-                appNamenamespace = K8SEDeploymentHelper.GetAppNamespace(httpContext);
+                appNamespace = K8SEDeploymentHelper.GetAppNamespace(httpContext);
                 appType = K8SEDeploymentHelper.GetAppKind(httpContext);
 
                 string homeDir = "";
                 if (OSDetector.IsOnWindows())
                 {
-                    homeDir = Constants.WindowsAppHomeDir;
+                    homeDir = PathResolver.ResolveWindowsAppHomeDir(appNamespace);
                 }
                 else
                 {
-                    homeDir = Constants.LinuxAppHomeDir;
+                    homeDir = PathResolver.ResolveLinuxAppHomeDir(appNamespace);
                 }
 
                 // Cache the App Environment for this request
@@ -366,7 +368,7 @@ namespace Kudu.Services.Web
             var kuduConsoleFullPath =
                 Path.Combine(AppContext.BaseDirectory, KuduConsoleRelativePath, KuduConsoleFilename);
             return new Environment(root, EnvironmentHelper.NormalizeBinPath(binPath), repositoryPath, requestId,
-                kuduConsoleFullPath, null, appName, appNamenamespace, appType);
+                kuduConsoleFullPath, null, appName, appNamespace, appType);
         }
 
         internal static void UpdateEnvironmentBySettings(IEnvironment environment,

--- a/Kudu.Services.Web/PathResolver.cs
+++ b/Kudu.Services.Web/PathResolver.cs
@@ -6,6 +6,16 @@ namespace Kudu.Services.Web
 {
     public static class PathResolver
     {
+        public static string ResolveWindowsAppHomeDir(string appNamespace)
+        {
+            return @"C:\repos\namespace\" + appNamespace + @"\apps\";
+        }
+
+        public static string ResolveLinuxAppHomeDir(string appNamespace)
+        {
+            return $"/home/namespace/{appNamespace}/apps/";
+        }
+
         public static string ResolveRootPath()
         {
             // The HOME path should always be set correctly
@@ -21,7 +31,7 @@ namespace Kudu.Services.Web
             }
 
             return path;
-            
+
         }
 
         /// <summary>

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -85,12 +85,11 @@ namespace Kudu.Services.Web
         {
             if (FileSystemHelpers.DirectoryExists("/home/apps"))
             {
-                Console.WriteLine(@"folder migration start: " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
-                
                 var defaultNamespace = System.Environment.GetEnvironmentVariable(SettingsKeys.PodNamespace);
                 var destinationFolder = PathResolver.ResolveLinuxAppHomeDir(defaultNamespace);
-                FileSystemHelpers.MoveDirectory("/home/apps", destinationFolder);
                 
+                Console.WriteLine($"folder migration start: from /home/apps to {destinationFolder}, time: {DateTime.Now.ToString("hh.mm.ss.ffffff")}");
+                FileSystemHelpers.MoveDirectory("/home/apps", destinationFolder);
                 Console.WriteLine($"folder migration finish: from /home/apps to {destinationFolder}");
             }
 

--- a/Kudu.Services.Web/Startup.cs
+++ b/Kudu.Services.Web/Startup.cs
@@ -83,6 +83,17 @@ namespace Kudu.Services.Web
         /// </todo>
         public void ConfigureServices(IServiceCollection services)
         {
+            if (FileSystemHelpers.DirectoryExists("/home/apps"))
+            {
+                Console.WriteLine(@"folder migration start: " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
+                
+                var defaultNamespace = System.Environment.GetEnvironmentVariable(SettingsKeys.PodNamespace);
+                var destinationFolder = PathResolver.ResolveLinuxAppHomeDir(defaultNamespace);
+                FileSystemHelpers.MoveDirectory("/home/apps", destinationFolder);
+                
+                Console.WriteLine($"folder migration finish: from /home/apps to {destinationFolder}");
+            }
+
             Console.WriteLine(@"Configure Services : " + DateTime.Now.ToString("hh.mm.ss.ffffff"));
 
             FileSystemHelpers.DeleteDirectorySafe("/home/site/locks/deployment");

--- a/Kudu.Services/DebugExtension/InstanceController.cs
+++ b/Kudu.Services/DebugExtension/InstanceController.cs
@@ -22,7 +22,7 @@ namespace Kudu.Services.DebugExtension
         {
             if(K8SEDeploymentHelper.IsK8SEEnvironment())
             {
-                return K8SEDeploymentHelper.GetInstances(K8SEDeploymentHelper.GetAppName(HttpContext));
+                return K8SEDeploymentHelper.GetInstances(K8SEDeploymentHelper.GetAppNamespace(HttpContext), K8SEDeploymentHelper.GetAppName(HttpContext));
             }
 
             return null;
@@ -34,7 +34,7 @@ namespace Kudu.Services.DebugExtension
         {
             if (K8SEDeploymentHelper.IsK8SEEnvironment())
             {
-                var instances = K8SEDeploymentHelper.GetInstances(K8SEDeploymentHelper.GetAppName(HttpContext));
+                var instances = K8SEDeploymentHelper.GetInstances(K8SEDeploymentHelper.GetAppNamespace(HttpContext), K8SEDeploymentHelper.GetAppName(HttpContext));
                 PodInstance instance = null;
                 if (instances.Count > 0)
                 {

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -623,7 +623,7 @@ namespace Kudu.Services.Deployment
                 return StatusCode(Microsoft.AspNetCore.Http.StatusCodes.Status405MethodNotAllowed);
             }
             string linuxFxVersion = Request.Headers["LINUXFXVERSION"].First().Replace("DOCKER|", "");
-            K8SEDeploymentHelper.UpdateImageTag(K8SEDeploymentHelper.GetAppName(Request.HttpContext), linuxFxVersion);
+            K8SEDeploymentHelper.UpdateImageTag(K8SEDeploymentHelper.GetAppNamespace(Request.HttpContext), K8SEDeploymentHelper.GetAppName(Request.HttpContext), linuxFxVersion);
             return Ok();
         }
 

--- a/Kudu.Tests/Core/Function/KafkaTriggerKedaAuthProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KafkaTriggerKedaAuthProviderTests.cs
@@ -38,7 +38,7 @@ namespace Kudu.Tests.Core.Function
         public void TestPopulateAuthenticationRef(string kafkaBindings, string appName)
         {
             Mock<KafkaTriggerKedaAuthProvider> mock = new Mock<KafkaTriggerKedaAuthProvider>();
-            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>())).Verifiable();
+            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>(), It.IsAny<String>())).Verifiable();
 
             IDictionary<string, string> authRef = getAuthRef(mock, kafkaBindings, appName);
             Assert.Equal(appName, authRef["name"]);
@@ -51,7 +51,7 @@ namespace Kudu.Tests.Core.Function
         public void TestIfTriggerAuthIsNull(string kafkaBindings, string appName)
         {
             Mock<KafkaTriggerKedaAuthProvider> mock = new Mock<KafkaTriggerKedaAuthProvider>();
-            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>())).Verifiable();
+            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>(), It.IsAny<String>())).Verifiable();
 
             IDictionary<string, string> authRef = getAuthRef(mock, kafkaBindings, appName);
             Assert.Null(authRef);
@@ -61,7 +61,7 @@ namespace Kudu.Tests.Core.Function
         public void PopulateAuthenticationRef_Fails_When_TriggerAuthCreationFails()
         {
             Mock<KafkaTriggerKedaAuthProvider> mock = new Mock<KafkaTriggerKedaAuthProvider>();
-            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>())).Throws(new Exception("exception in trigger auth creation"));
+            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>(), It.IsAny<String>())).Throws(new Exception("exception in trigger auth creation"));
 
             IDictionary<string, string> authRef = getAuthRef(mock, kafkaBindings, "testfunctionName");
             Assert.Null(authRef);
@@ -71,8 +71,8 @@ namespace Kudu.Tests.Core.Function
         public void PopulateAuthenticationRef_Continues_When_AddSecretsFails()
         {
             Mock<KafkaTriggerKedaAuthProvider> mock = new Mock<KafkaTriggerKedaAuthProvider>();
-            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>())).Verifiable();
-            mock.Setup(m => m.AddTriggerAuthAppSettingsSecrets(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>())).Throws(new Exception("exception for unit test"));
+            mock.Setup(m => m.CreateTriggerAuthenticationRef(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>(), It.IsAny<String>())).Verifiable();
+            mock.Setup(m => m.AddTriggerAuthAppSettingsSecrets(It.IsAny<Dictionary<string, string>>(), It.IsAny<String>(), It.IsAny<String>())).Throws(new Exception("exception for unit test"));
 
             IDictionary<string, string> authRef = getAuthRef(mock, kafkaBindings, "testFunctionName");
             Assert.Equal("testFunctionName", authRef["name"]);
@@ -82,7 +82,7 @@ namespace Kudu.Tests.Core.Function
         {
             KafkaTriggerKedaAuthProvider kafkaTriggerKedaAuthProvider = mock.Object;
             JToken jsonObj = JToken.Parse(kafkaBindings);
-            return kafkaTriggerKedaAuthProvider.PopulateAuthenticationRef(jsonObj, appName);
+            return kafkaTriggerKedaAuthProvider.PopulateAuthenticationRef(jsonObj, appName, "default");
         }
     }   
 }

--- a/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
+++ b/Kudu.Tests/Core/Function/KedaFunctionTriggersProviderTests.cs
@@ -29,7 +29,7 @@ namespace Kudu.Tests.Core.Function
 
             try
             {
-                IEnumerable<ScaleTrigger> result = KedaFunctionTriggerProvider.GetFunctionTriggers(zipFilePath);
+                IEnumerable<ScaleTrigger> result = KedaFunctionTriggerProvider.GetFunctionTriggers("default", zipFilePath);
                 ValidateDurableTriggers(result);
             }
             finally
@@ -78,7 +78,7 @@ namespace Kudu.Tests.Core.Function
 
             try
             {
-                IEnumerable<ScaleTrigger> result = KedaFunctionTriggerProvider.GetFunctionTriggers(zipFilePath, appName, appType);
+                IEnumerable<ScaleTrigger> result = KedaFunctionTriggerProvider.GetFunctionTriggers("default", zipFilePath, appName, appType);
                 Assert.Single(result);
 
                 ScaleTrigger queueTrigger = Assert.Single(result, trigger => trigger.Type.Equals("azure-queue", StringComparison.OrdinalIgnoreCase));
@@ -265,7 +265,7 @@ namespace Kudu.Tests.Core.Function
             
             var jsonObj = JObject.Parse(jsonText);
 
-            var triggers = KedaFunctionTriggerProvider.GetFunctionTriggers(new[] { jsonObj }, string.Empty, new Dictionary<string, string>());
+            var triggers = KedaFunctionTriggerProvider.GetFunctionTriggers(string.Empty, new[] { jsonObj }, string.Empty, new Dictionary<string, string>());
 
             Assert.Equal(0, triggers.Count());
         }

--- a/Kudu.Tests/Core/Function/SyncTriggerHandlerTests.cs
+++ b/Kudu.Tests/Core/Function/SyncTriggerHandlerTests.cs
@@ -17,7 +17,7 @@ namespace Kudu.Tests.Core.Function
         public void GetScaleTriggersTest(string functionTriggerPayload)
         {
             var syncTriggerHandler = new SyncTriggerHandler(null, null, null);
-            var scaleTriggers = syncTriggerHandler.GetScaleTriggers(functionTriggerPayload);
+            var scaleTriggers = syncTriggerHandler.GetScaleTriggers("default", functionTriggerPayload);
             if (string.Equals(functionTriggerPayload, "Invalid json") || string.IsNullOrEmpty(functionTriggerPayload))
             {
                 Assert.True(!string.IsNullOrEmpty(scaleTriggers.Item2));
@@ -44,7 +44,7 @@ namespace Kudu.Tests.Core.Function
             string serializedPayload = syncTriggersPayloadJson.ToString(Formatting.None);
 
             var syncTriggerHandler = new SyncTriggerHandler(null, null, null);
-            (IEnumerable<ScaleTrigger> triggers, string error) = syncTriggerHandler.GetScaleTriggers(serializedPayload);
+            (IEnumerable<ScaleTrigger> triggers, string error) = syncTriggerHandler.GetScaleTriggers("default", serializedPayload);
             Assert.Null(error);
             Assert.NotNull(triggers);
 


### PR DESCRIPTION
* pass namespace info when invoke build ctl
* Originally the app root path is /home/apps, this PR change the path to /home/namespace/{namespace}/apps to avoid conflict.
* To ensure compatibility, do migration when start up: move all files from /home/apps to /home/namespace/{namespace}/apps
